### PR TITLE
Clarify playground execution modes

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -5,8 +5,10 @@ Web-based interactive playground for the Vais programming language.
 ## Features
 
 - **Monaco Editor** with Vais syntax highlighting
-- **Server-backed compilation** when the playground API is available, with
-  preview fallback
+- **Server-backed compilation** when the playground API is available
+- **Server-WASM execution** where the API compiles a WASM binary and the browser
+  executes it
+- **Preview fallback** for syntax/demo exploration when the API is unavailable
 - **31 example programs** demonstrating language features
 - **Auto-completion** for Vais keywords and functions
 - **Keyboard shortcuts** for quick actions
@@ -111,11 +113,12 @@ Press `Ctrl+Space` to see suggestions for:
 
 ### Execution Modes
 
-The playground uses automatic fallback:
+The playground uses automatic fallback. The current certified public baseline
+does not include browser-only compilation or execution.
 
-1. **Server mode** — Sends code to the playground server for real compilation via `vaisc`
-2. **Preview mode** — Client-side syntax/demo fallback when the server is unavailable
-3. **WASM mode** — Experimental browser path; not part of the certified Core baseline
+1. **Server mode** — Sends code to the playground API for real compilation via `vaisc`
+2. **Server-WASM mode** — The API compiles a WASM binary, then the browser executes that binary
+3. **Preview mode** — Client-side syntax/demo fallback when the API is unavailable; this is not a certified compile/execute path
 
 ## Development
 
@@ -167,7 +170,7 @@ Edit `src/styles.css` to customize the appearance.
 
 ## Future Enhancements
 
-- [ ] Certified browser WASM compilation gate
+- [ ] Certified browser-only WASM compilation gate
 - [ ] Code sharing via URL
 - [ ] Multi-file projects
 - [ ] Standard library documentation integration

--- a/playground/src/compiler.js
+++ b/playground/src/compiler.js
@@ -1,5 +1,5 @@
 // Compiler interface for Vais
-// Supports server-side compilation, WASM execution, and mock mode (fallback)
+// Supports server-side compilation, server-backed WASM execution, and preview fallback.
 
 import { WasmRunner } from './wasm-runner.js';
 
@@ -9,7 +9,8 @@ const DEFAULT_API_URL = import.meta.env.VITE_API_URL || (
     : 'https://api.vaislang.dev'
 );
 
-// Compilation modes
+// Compilation modes. MODE_WASM still depends on the playground API for
+// compilation; only the generated WASM binary executes in the browser.
 const MODE_SERVER = 'server';
 const MODE_WASM = 'wasm';
 const MODE_MOCK = 'mock';
@@ -41,7 +42,7 @@ export class VaisCompiler {
       console.warn('Playground server not available');
     }
 
-    // WASM availability check is deferred until first compile attempt
+    // Server-backed WASM availability check is deferred until first compile attempt
     // to avoid blocking initial page load with a 5s timeout probe.
     if (!this.serverAvailable) {
       this.mode = MODE_MOCK;
@@ -51,7 +52,7 @@ export class VaisCompiler {
     return true;
   }
 
-  /** Lazy WASM probe: called on first compile when server is unavailable */
+  /** Lazy server-backed WASM probe: called on first compile when health is unavailable */
   async _probeWasm() {
     if (this._wasmProbed) return;
     this._wasmProbed = true;
@@ -65,10 +66,10 @@ export class VaisCompiler {
       if (response.ok) {
         this.wasmAvailable = true;
         this.mode = MODE_WASM;
-        console.log('WASM compilation available');
+        console.log('Server-backed WASM compilation available');
       }
     } catch {
-      // WASM compilation not available
+      // Server-backed WASM compilation not available
     }
   }
 
@@ -81,7 +82,7 @@ export class VaisCompiler {
   getModeLabel() {
     switch (this.mode) {
       case MODE_SERVER: return 'Server';
-      case MODE_WASM: return 'WASM';
+      case MODE_WASM: return 'Server-WASM';
       case MODE_MOCK: return 'Preview';
       default: return 'Unknown';
     }
@@ -153,8 +154,8 @@ export class VaisCompiler {
     return this.mockCompileAndRun(sourceCode);
   }
 
-  // --- WASM compilation mode ---
-  // Server compiles to WASM, then we execute in browser
+  // --- Server-backed WASM mode ---
+  // The API compiles to WASM, then this page executes the binary in the browser.
 
   async wasmCompileAndRun(sourceCode) {
     try {
@@ -204,7 +205,7 @@ export class VaisCompiler {
       const execTimeMs = Math.round(performance.now() - execStart);
 
       let output = result.output || '';
-      output += `\n\n[WASM mode — compiled in ${compileTimeMs}ms, executed in ${execTimeMs}ms]`;
+      output += `\n\n[Server-WASM mode — API compiled in ${compileTimeMs}ms, browser executed in ${execTimeMs}ms]`;
 
       return {
         success: result.success,
@@ -215,7 +216,7 @@ export class VaisCompiler {
         compileTimeMs: compileTimeMs + execTimeMs,
       };
     } catch (error) {
-      // If WASM mode fails, fall back to mock
+      // If Server-WASM mode fails, fall back to preview
       if (error.name === 'TimeoutError' || error.name === 'TypeError') {
         this.wasmAvailable = false;
         this.mode = MODE_MOCK;
@@ -407,7 +408,7 @@ export class VaisCompiler {
       outputText = `Program compiled successfully (${summary.join(', ')})`;
     }
 
-    outputText += '\n\n[Preview mode — compile server offline. Install locally: cargo install vaisc]';
+    outputText += '\n\n[Preview mode — syntax/demo fallback only; compile server offline. Install locally: cargo install vaisc]';
 
     return {
       success: true,

--- a/website/index.html
+++ b/website/index.html
@@ -491,7 +491,7 @@
     <div class="container">
       <h2 class="section-title" data-i18n="playground.title">Try Vais Now</h2>
       <p class="section-subtitle" data-i18n="playground.subtitle">
-        Write and run Vais code directly in your browser. No installation required.
+        Try Vais syntax and examples in the browser. Real compilation uses the playground API; browser-only compile/execute remains experimental.
       </p>
       <div class="playground-embed" id="playground-container">
         <div class="playground-placeholder" id="playground-placeholder">

--- a/website/public/locales/en.json
+++ b/website/public/locales/en.json
@@ -76,7 +76,7 @@
   },
   "playground": {
     "title": "Try Vais Now",
-    "subtitle": "Try Vais syntax and examples in the browser. Server-backed compilation is used when available; browser-only JS/WASM paths are experimental.",
+    "subtitle": "Try Vais syntax and examples in the browser. Real compilation uses the playground API; browser-only compile/execute remains experimental.",
     "launch": "Launch Interactive Playground",
     "loadHere": "Load Playground Here",
     "openTab": "Open in New Tab"

--- a/website/public/locales/ja.json
+++ b/website/public/locales/ja.json
@@ -76,7 +76,7 @@
   },
   "playground": {
     "title": "今すぐVaisを試す",
-    "subtitle": "ブラウザで Vais syntax と examples を試せます。Server-backed compilation は API がある場合に使い、JS/WASM browser path は experimental です。",
+    "subtitle": "ブラウザで Vais syntax と examples を試せます。実際の compilation は playground API を使い、browser-only compile/execute はまだ experimental です。",
     "launch": "インタラクティブプレイグラウンドを起動",
     "loadHere": "ここにプレイグラウンドを読み込む",
     "openTab": "新しいタブで開く"

--- a/website/public/locales/ko.json
+++ b/website/public/locales/ko.json
@@ -76,7 +76,7 @@
   },
   "playground": {
     "title": "지금 Vais를 시도해보세요",
-    "subtitle": "브라우저에서 Vais syntax와 examples를 실험할 수 있습니다. Server-backed compilation은 API가 있을 때 사용되며 JS/WASM browser path는 experimental입니다.",
+    "subtitle": "브라우저에서 Vais syntax와 examples를 실험할 수 있습니다. 실제 compilation은 playground API를 사용하며, browser-only compile/execute는 아직 experimental입니다.",
     "launch": "대화형 플레이그라운드 시작",
     "loadHere": "여기에 플레이그라운드 로드",
     "openTab": "새 탭에서 열기"

--- a/website/public/locales/zh.json
+++ b/website/public/locales/zh.json
@@ -76,7 +76,7 @@
   },
   "playground": {
     "title": "立即试用 Vais",
-    "subtitle": "在浏览器中试用 Vais syntax 和 examples。Server-backed compilation 在 API 可用时使用；JS/WASM browser path 是 experimental。",
+    "subtitle": "在浏览器中试用 Vais syntax 和 examples。实际 compilation 使用 playground API；browser-only compile/execute 仍是 experimental。",
     "launch": "启动交互式在线试用",
     "loadHere": "在此处加载在线试用",
     "openTab": "在新标签页中打开"


### PR DESCRIPTION
## Summary
- distinguish Server, Server-WASM, and Preview playground modes
- clarify that Server-WASM still uses the playground API for compilation and only executes the generated WASM in-browser
- align website and locale copy with the browser-only compile/execute non-claim

## Verification
- git diff --check origin/main..HEAD
- npm run build (playground)
- npm run build (website)

Note: npm ci reported existing npm audit warnings from the current lockfiles; this PR does not change dependencies.