### PR TITLE
Add public claim guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,22 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  # ---------- Public claim guard ----------
+  public-claims:
+    name: Public Claim Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check public claims
+        run: node scripts/check-public-claims.mjs
+
   # ---------- Documentation check ----------
   docs:
     name: Documentation

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -37,6 +37,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
 
+      - name: Check public claims
+        run: node scripts/check-public-claims.mjs
+
       - name: Install mdBook
         run: |
           curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xz

--- a/PUBLIC_STATUS.md
+++ b/PUBLIC_STATUS.md
@@ -69,3 +69,7 @@ Avoid broad wording unless a named gate backs it:
 
 If a page makes a capability claim, it should name the gate, test count, or
 scope that supports the claim.
+
+The repository enforces the highest-risk public wording boundaries with
+`scripts/check-public-claims.mjs`; update that guard when promoting a non-claim
+to a certified gate.

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function read(path) {
+  return readFileSync(resolve(root, path), 'utf8');
+}
+
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function requireText(path, expected, reason) {
+  const content = read(path);
+  if (!content.includes(expected)) {
+    fail(`${path}: missing "${expected}" (${reason})`);
+  }
+}
+
+function requirePattern(path, pattern, reason) {
+  const content = read(path);
+  if (!pattern.test(content)) {
+    fail(`${path}: missing pattern ${pattern} (${reason})`);
+  }
+}
+
+function forbidPattern(path, pattern, reason) {
+  const content = read(path);
+  if (pattern.test(content)) {
+    fail(`${path}: forbidden pattern ${pattern} (${reason})`);
+  }
+}
+
+function forbidText(path, forbidden, reason) {
+  const content = read(path);
+  if (content.includes(forbidden)) {
+    fail(`${path}: forbidden "${forbidden}" (${reason})`);
+  }
+}
+
+const publicStatus = 'PUBLIC_STATUS.md';
+requireText(
+  publicStatus,
+  'The current certified baseline is a core compiler and promoted-runtime',
+  'public baseline must not claim product-complete status',
+);
+requireText(
+  publicStatus,
+  'It is not a product-complete v1.0 release.',
+  'public baseline must not claim product-complete status',
+);
+requireText(
+  publicStatus,
+  'Complete browser-only playground compilation and execution',
+  'browser-only playground compile/execute remains a public non-claim',
+);
+
+const playgroundCompiler = 'playground/src/compiler.js';
+requireText(
+  playgroundCompiler,
+  "case MODE_WASM: return 'Server-WASM';",
+  'UI mode label must show that WASM compilation is server-backed',
+);
+requirePattern(
+  playgroundCompiler,
+  /Server-WASM mode\s+\u2014\s+API compiled/,
+  'runtime output must state that the API compiled the WASM binary',
+);
+requirePattern(
+  playgroundCompiler,
+  /Preview mode\s+\u2014\s+syntax\/demo fallback only/,
+  'preview fallback must not imply certified compilation',
+);
+forbidPattern(
+  playgroundCompiler,
+  /case\s+MODE_WASM:\s+return\s+['"]WASM['"]/,
+  'plain WASM label hides the server-backed compile dependency',
+);
+forbidPattern(
+  playgroundCompiler,
+  /\[WASM mode\s+[\u2014-]\s+compiled/,
+  'plain WASM output hides the server-backed compile dependency',
+);
+
+const playgroundReadme = 'playground/README.md';
+requireText(
+  playgroundReadme,
+  'Server-WASM mode',
+  'playground README must name the server-backed WASM mode',
+);
+requireText(
+  playgroundReadme,
+  'does not include browser-only compilation or execution',
+  'playground README must keep the browser-only non-claim explicit',
+);
+requireText(
+  playgroundReadme,
+  'this is not a certified compile/execute path',
+  'preview mode must be documented as non-certified',
+);
+
+const websiteSubtitle =
+  'Try Vais syntax and examples in the browser. Real compilation uses the playground API; browser-only compile/execute remains experimental.';
+requireText('website/index.html', websiteSubtitle, 'homepage playground copy must match public claim boundary');
+requireText('website/public/locales/en.json', websiteSubtitle, 'English locale must match public claim boundary');
+
+for (const locale of ['ko', 'ja', 'zh']) {
+  const path = `website/public/locales/${locale}.json`;
+  requireText(path, 'playground API', `${locale} locale must name the API dependency`);
+  requireText(path, 'browser-only compile/execute', `${locale} locale must keep browser-only status experimental`);
+}
+
+for (const path of [
+  'website/index.html',
+  'website/public/locales/en.json',
+  'website/public/locales/ko.json',
+  'website/public/locales/ja.json',
+  'website/public/locales/zh.json',
+]) {
+  forbidText(
+    path,
+    'Write and run Vais code directly in your browser. No installation required.',
+    'homepage must not imply certified browser-only execution',
+  );
+  forbidText(
+    path,
+    'browser-only JS/WASM paths are experimental',
+    'use the clearer compile/execute wording introduced by the claim boundary',
+  );
+}
+
+if (failures.length > 0) {
+  console.error('Public claim guard failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Public claim guard passed (${relative(root, resolve(root)) || '.'}).`);


### PR DESCRIPTION
## Summary
- add a Node-based guard for high-risk public wording boundaries
- fail CI if playground/site copy implies certified browser-only compile/execute
- run the guard in CI and before website deployment

## Verification
- node scripts/check-public-claims.mjs
- git diff --check origin/main..HEAD
- npm run build (website)
- npm run build (playground)

Note: npm ci reported existing npm audit warnings from current lockfiles; this PR does not change dependencies.