### PR TITLE
Add playground web mode gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,33 @@ jobs:
       - name: Check public claims
         run: node scripts/check-public-claims.mjs
 
+  # ---------- Playground web gate ----------
+  playground-web:
+    name: Playground Web Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: playground/package-lock.json
+
+      - name: Install playground dependencies
+        working-directory: playground
+        run: npm ci
+
+      - name: Check playground mode contract
+        working-directory: playground
+        run: npm run test:contract
+
+      - name: Build playground
+        working-directory: playground
+        run: npm run build
+
   # ---------- Documentation check ----------
   docs:
     name: Documentation

--- a/PUBLIC_STATUS.md
+++ b/PUBLIC_STATUS.md
@@ -29,6 +29,8 @@ The latest local integrity pass covers:
 - Ecosystem package tests: `3272/3272`
 - Vais Web full-build gate: `24/24`
 - Package full-build gate: `2/2`
+- Playground web mode/build gate: passed; Server-WASM remains API-compiled,
+  and Preview remains a syntax/demo fallback only
 
 ## Public Non-Claims
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,8 @@ source_of_truth: `PUBLIC_STATUS.md`
 - Ecosystem package tests: `3272/3272`
 - Vais Web full-build gate: `24/24`
 - Package full-build gate: `2/2`
+- Playground web mode/build gate: passed; Server-WASM remains API-compiled,
+  and Preview remains a syntax/demo fallback only
 
 ### 공개 non-claim
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -122,6 +122,16 @@ does not include browser-only compilation or execution.
 
 ## Development
 
+### Local Gates
+
+```bash
+npm run test:contract
+npm run build
+```
+
+`test:contract` verifies the public mode boundary: Server-WASM is API-compiled,
+and Preview is only a syntax/demo fallback.
+
 ### Adding New Examples
 
 Edit `src/examples.js`:

--- a/playground/package.json
+++ b/playground/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test:contract": "node ../scripts/check-playground-mode-contract.mjs",
     "wasm:build": "cd .. && cargo build --release --target wasm32-unknown-unknown --package vaisc"
   },
   "dependencies": {

--- a/playground/src/compiler.js
+++ b/playground/src/compiler.js
@@ -3,8 +3,11 @@
 
 import { WasmRunner } from './wasm-runner.js';
 
-const DEFAULT_API_URL = import.meta.env.VITE_API_URL || (
-  window.location.hostname === 'localhost'
+const viteEnv = import.meta.env || {};
+const runtimeWindow = globalThis.window;
+
+const DEFAULT_API_URL = viteEnv.VITE_API_URL || (
+  runtimeWindow?.location?.hostname === 'localhost'
     ? 'http://localhost:8080'
     : 'https://api.vaislang.dev'
 );

--- a/scripts/check-playground-mode-contract.mjs
+++ b/scripts/check-playground-mode-contract.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const compilerUrl = pathToFileURL(resolve(root, 'playground/src/compiler.js')).href;
+
+// Minimal module:
+// (module (func $main (result i32) i32.const 0) (export "main" (func $main)))
+const MINIMAL_WASM_BASE64 = 'AGFzbQEAAAABBQFgAAF/AwIBAAcIAQRtYWluAAAKBgEEAEEACw==';
+
+globalThis.window = {
+  location: {
+    hostname: 'localhost',
+  },
+};
+
+const { VaisCompiler } = await import(compilerUrl);
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+  };
+}
+
+async function testPreviewFallbackIsExplicitlyNonCertified() {
+  globalThis.fetch = async () => {
+    throw new TypeError('offline');
+  };
+
+  const compiler = new VaisCompiler('http://localhost:8080');
+  const result = await compiler.compileAndRun('F main(){ puts("hello") }');
+
+  assert.equal(compiler.getModeLabel(), 'Preview');
+  assert.equal(result.success, true);
+  assert.match(result.output, /hello/);
+  assert.match(result.output, /Preview mode\s+\u2014\s+syntax\/demo fallback only/);
+  assert.doesNotMatch(result.output, /compiled in \d+ms/);
+}
+
+async function testServerWasmModeNamesApiCompileBoundary() {
+  const calls = [];
+
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+
+    if (String(url).endsWith('/api/health')) {
+      throw new TypeError('health offline');
+    }
+
+    if (String(url).endsWith('/api/compile-wasm')) {
+      return jsonResponse({
+        success: true,
+        errors: [],
+        warnings: [],
+        wasm_binary: MINIMAL_WASM_BASE64,
+        compile_time_ms: 7,
+      });
+    }
+
+    throw new Error(`unexpected fetch URL: ${url}`);
+  };
+
+  const compiler = new VaisCompiler('http://localhost:8080');
+  const result = await compiler.compileAndRun('F main()->i64{0}', 'wasm');
+
+  assert.equal(compiler.getModeLabel(), 'Server-WASM');
+  assert.equal(result.success, true);
+  assert.match(result.output, /Server-WASM mode\s+\u2014\s+API compiled in 7ms, browser executed in \d+ms/);
+  assert.ok(calls.some((url) => url.endsWith('/api/compile-wasm')));
+  assert.ok(!calls.some((url) => url.endsWith('/api/compile')));
+}
+
+await testPreviewFallbackIsExplicitlyNonCertified();
+await testServerWasmModeNamesApiCompileBoundary();
+
+console.log('Playground mode contract passed.');

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -60,6 +60,16 @@ requireText(
   'Complete browser-only playground compilation and execution',
   'browser-only playground compile/execute remains a public non-claim',
 );
+requireText(
+  publicStatus,
+  'Playground web mode/build gate: passed',
+  'playground web gate can be claimed only as a mode/build contract',
+);
+requireText(
+  publicStatus,
+  'Server-WASM remains API-compiled',
+  'playground status must keep the server compile boundary explicit',
+);
 
 const playgroundCompiler = 'playground/src/compiler.js';
 requireText(
@@ -103,6 +113,11 @@ requireText(
   playgroundReadme,
   'this is not a certified compile/execute path',
   'preview mode must be documented as non-certified',
+);
+requireText(
+  playgroundReadme,
+  'test:contract',
+  'playground README must document the local mode contract gate',
 );
 
 const websiteSubtitle =


### PR DESCRIPTION
## Summary
- add a playground mode contract smoke test for Preview and Server-WASM boundaries
- run the playground mode contract and Vite build in CI
- document the gate in PUBLIC_STATUS, ROADMAP, and playground README

## Verification
- node scripts/check-public-claims.mjs
- npm run test:contract (playground)
- npm run build (playground)
- git diff --cached --check