### PR TITLE
Scope public claims to main evidence and integration evidence

### DIFF
--- a/PUBLIC_STATUS.md
+++ b/PUBLIC_STATUS.md
@@ -1,6 +1,6 @@
 # Vais Public Status
 
-Last verified: 2026-05-12
+Last verified: 2026-05-13
 
 This document is the public wording boundary for the Vais repositories and
 website. It separates the gates that are currently certified from broader
@@ -9,14 +9,37 @@ unverified.
 
 ## Certified Baseline
 
-The current certified baseline is a core compiler and promoted-runtime
-baseline. It is not a product-complete v1.0 release.
+The current certified baseline is a core compiler and promoted-runtime evidence
+baseline, with reproducibility scope split as follows.
 
-The latest local integrity pass covers:
+The current public baseline has two evidence tiers:
+
+1. Main-reproducible gates that run from the current `origin/main` tree.
+2. Integration evidence gathered on the long-running
+   `codex/ssr-json-grammar-gate` branch and the local multi-repository
+   workspace.
+
+It is not a product-complete v1.0 release.
+
+The current `origin/main` tree directly enforces:
+
+- Public claim guard: `node scripts/check-public-claims.mjs`
+- Website, docs, and playground GitHub Pages build/deploy workflow
+- Playground web mode/build gate: passed; Server-WASM remains API-compiled,
+  and Preview remains a syntax/demo fallback only
+- Browser-JS playground smoke gate: passed for parser + JavaScript codegen
+  compile/execute in the browser; this is not a complete browser-only language
+  implementation claim
+
+The following counts are integration evidence from
+`codex/ssr-json-grammar-gate` and the local workspace as of 2026-05-12. They
+are public evidence, but are not yet reproducible from `origin/main` until the
+aggregate integrity runner, product fixtures, and ecosystem runtime gates are
+ported to main:
 
 - Core compiler freeze bundle: passed
 - Downstream re-entry criteria: passed
-- Final integrity gate: passed via `scripts/check-integrity.sh`
+- Aggregate integrity runner: pending main port
 - Standard library package tests: `82/82`
 - VaisDB package tests: `261/261`
 - Backend package tests: `18/18`
@@ -31,11 +54,6 @@ The latest local integrity pass covers:
 - Package full-build gate: `2/2`
 - Cross-package schema gate: `15/15`
 - Multi-domain product schema gate: `9/9`
-- Playground web mode/build gate: passed; Server-WASM remains API-compiled,
-  and Preview remains a syntax/demo fallback only
-- Browser-JS playground smoke gate: passed for parser + JavaScript codegen
-  compile/execute in the browser; this is not a complete browser-only language
-  implementation claim
 
 ## Public Non-Claims
 
@@ -53,13 +71,17 @@ The current baseline does not certify:
 - Broad external network reliability outside the promoted local smoke gates
 - Product-complete VaisDB, Vais Server, or Vais Web behavior
 - Complete API documentation for every standard-library module
+- Main-branch reproducibility for the full aggregate integrity gate until the
+  pending main-port work lands
 
 ## Public Wording Policy
 
-Use gate-backed wording:
+Use evidence-scoped wording:
 
 - "certified core compiler"
 - "promoted runtime smoke gate"
+- "integration evidence"
+- "pending main port"
 - "source-build baseline"
 - "experimental target"
 - "design target"

--- a/docs/PUBLIC_CLAIM_EVIDENCE.md
+++ b/docs/PUBLIC_CLAIM_EVIDENCE.md
@@ -1,0 +1,46 @@
+# Public Claim Evidence Audit
+
+Last audited: 2026-05-13
+
+This document records whether high-risk public claims are reproducible from the
+current `origin/main` tree or are integration evidence from the long-running
+gate branch.
+
+## Main-Reproducible Evidence
+
+| Claim area | Evidence in `origin/main` |
+|---|---|
+| Public wording boundary | `node scripts/check-public-claims.mjs` |
+| Website/docs/playground deployment | `.github/workflows/website.yml` |
+| Playground mode boundary | `scripts/check-playground-mode-contract.mjs` |
+| Browser-JS playground smoke | `scripts/check-browser-compiler-gate.mjs` |
+
+## Integration Evidence Pending Main Port
+
+The following counts are public evidence from `codex/ssr-json-grammar-gate`
+and the local multi-repository workspace, but the aggregate runner and product
+fixtures are not yet present on `origin/main`.
+
+| Claim area | Integration evidence | Main status |
+|---|---:|---|
+| Aggregate integrity runner | `scripts/check-integrity.sh` | Pending main port |
+| Std package codegen | `82/82` | Pending aggregate gate port |
+| VaisDB package codegen | `261/261` | Pending aggregate gate port |
+| Backend smoke | `18/18` | Pending aggregate gate port |
+| HTTP client runtime | `15/15` | Pending aggregate gate port |
+| TLS runtime | `2/2` | Pending aggregate gate port |
+| VaisDB runtime | `34/34` | Pending aggregate gate port |
+| vais-server runtime | `20/20` | Pending aggregate gate port |
+| Vais Web runtime | `61/77` | Pending ecosystem gate port |
+| Vais Web unit | `390/390` | Pending ecosystem gate port |
+| Vais Web packages | `3272/3272` | Pending ecosystem gate port |
+| Vais Web full-build | `24/24` | Pending ecosystem gate port |
+| Cross-package schema | `15/15` | Pending fixture + runner port |
+| Multi-domain product schema | `9/9` | Pending fixture + runner port |
+| Package full-build | `2/2` | Pending aggregate gate port |
+
+## Required Resolution
+
+Public pages may cite these numbers only as evidence-scoped claims. They must
+not imply that the full aggregate gate is reproducible from `origin/main` until
+the runner, fixtures, and ecosystem package gates are ported and passing there.

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -82,18 +82,33 @@ requireText(
 );
 requireText(
   publicStatus,
+  'not yet reproducible from `origin/main`',
+  'integration evidence must not be presented as main-reproducible yet',
+);
+requireText(
+  publicStatus,
+  'Aggregate integrity runner: pending main port',
+  'aggregate integrity status must be explicit until the runner is on main',
+);
+forbidText(
+  publicStatus,
+  'Final integrity gate: passed via `scripts/check-integrity.sh`',
+  'origin/main does not currently contain the aggregate integrity runner',
+);
+requireText(
+  publicStatus,
   'Vais Server runtime smoke: `20/20`',
-  'server public baseline must match the promoted runtime gate',
+  'server public evidence count must remain explicit',
 );
 requireText(
   publicStatus,
   'Cross-package schema gate: `15/15`',
-  'schema propagation must be named as a gate-backed public claim',
+  'schema propagation must be named as an evidence-scoped public claim',
 );
 requireText(
   publicStatus,
   'Multi-domain product schema gate: `9/9`',
-  'shared-schema product propagation must be named as a gate-backed public claim',
+  'shared-schema product propagation must be named as evidence-scoped public claim',
 );
 
 const playgroundCompiler = 'playground/src/compiler.js';
@@ -159,11 +174,13 @@ const websiteSubtitle =
   'Try Vais syntax and examples in the browser. Real compilation uses the playground API; browser-only compile/execute remains experimental.';
 requireText('website/index.html', websiteSubtitle, 'homepage playground copy must match public claim boundary');
 requireText('website/public/locales/en.json', websiteSubtitle, 'English locale must match public claim boundary');
-requireText('website/index.html', 'server runtime smoke 20/20', 'homepage server claim must match the promoted runtime gate');
-requireText('website/index.html', 'shared-schema product gate 9/9', 'homepage web claim must name the shared-schema product gate');
-requireText('website/ecosystem/index.html', 'server runtime 20/20', 'ecosystem server claim must match the promoted runtime gate');
-requireText('website/ecosystem/index.html', 'shared-schema product 9/9 gate', 'ecosystem web claim must name the shared-schema product gate');
-requireText('website/vaisx/index.html', 'shared-schema product gate 9/9', 'VaisX page must name the shared-schema product gate');
+requireText('website/index.html', 'Evidence Snapshot', 'homepage must scope gate counts as evidence');
+requireText('website/index.html', 'pending main port', 'homepage must disclose aggregate/product gate main-port status');
+requireText('website/index.html', 'server runtime integration evidence 20/20', 'homepage server claim must be evidence-scoped');
+requireText('website/index.html', 'shared-schema product evidence 9/9', 'homepage web claim must be evidence-scoped');
+requireText('website/ecosystem/index.html', 'server runtime 20/20', 'ecosystem server evidence count must remain explicit');
+requireText('website/ecosystem/index.html', 'integration evidence', 'ecosystem page must disclose evidence scope');
+requireText('website/vaisx/index.html', 'shared-schema product evidence 9/9', 'VaisX page must be evidence-scoped');
 requireText('playground/src/examples.js', "'shared-schema-product'", 'playground must expose the shared-schema product example');
 
 for (const locale of ['ko', 'ja', 'zh']) {

--- a/website/ecosystem/index.html
+++ b/website/ecosystem/index.html
@@ -520,7 +520,7 @@
       </h1>
       <p class="eco-hero-subtitle">
         하나의 언어로 프론트엔드, 백엔드, 데이터베이스를 모두.
-        현재 공개 기준은 제품 완성이 아니라 명시된 package/runtime/full-build/schema gate로 검증된 범위입니다.
+        현재 공개 기준은 제품 완성이 아니라 main 재현 gate와 integration evidence를 구분한 범위입니다.
       </p>
       <div class="eco-hero-actions">
         <a href="https://docs.vaislang.dev/ecosystem/" class="btn btn-primary">Get Started</a>
@@ -533,7 +533,7 @@
 
         <div class="arch-layer arch-layer-browser">
           <span class="arch-label">[ Browser ]</span>
-          <span class="arch-desc">VaisX (vais-web) — runtime 61/77, unit 390/390, full-build 24/24, schema 9/9</span>
+          <span class="arch-desc">VaisX (vais-web) — integration evidence: runtime 61/77, unit 390/390, full-build 24/24, schema 9/9</span>
         </div>
 
         <div class="arch-arrow">↕  HTTP / WebSocket  ↕</div>
@@ -577,7 +577,7 @@
           <div class="product-tagline">vais-web · 웹 프레임워크 workbench</div>
           <p class="product-desc">
             컴파일 타임 반응성과 DOM 업데이트 생성을 목표로 하는 웹 프레임워크.
-            현재 공개 claim은 runtime 61/77, unit 390/390, full-build 24/24, shared-schema product 9/9 gate에 묶입니다.
+            현재 공개 claim은 integration evidence runtime 61/77, unit 390/390, full-build 24/24, shared-schema product 9/9에 묶입니다.
           </p>
           <ul class="product-features">
             <li>컴파일 타임 반응성 구현 표면</li>
@@ -598,7 +598,7 @@
           <div class="product-tagline">RAG-native 하이브리드 데이터베이스</div>
           <p class="product-desc">
             벡터 검색, 그래프 쿼리, SQL, 전문 검색(FTS)을 단일 엔진으로 묶는
-            데이터베이스 workbench. 현재 gate는 package 261/261, runtime 34/34입니다.
+            데이터베이스 workbench. 현재 integration evidence는 package 261/261, runtime 34/34입니다.
           </p>
           <ul class="product-features">
             <li>Vector + Graph + SQL + FTS 구현 표면</li>
@@ -619,7 +619,7 @@
           <div class="product-tagline">백엔드 프레임워크 workbench</div>
           <p class="product-desc">
             Express/Axum 스타일 라우팅 API를 제공하는 HTTP 서버 workbench.
-            현재 gate는 server runtime 20/20이며, broad protocol/auth/deploy claim은 별도 gate가 필요합니다.
+            현재 integration evidence는 server runtime 20/20이며, broad protocol/auth/deploy claim은 별도 gate가 필요합니다.
           </p>
           <ul class="product-features">
             <li>Express / Axum 스타일 선언형 라우팅</li>

--- a/website/index.html
+++ b/website/index.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Vais - AI-Optimized Systems Programming Language</title>
-  <meta name="description" content="Vais is a systems programming language designed for AI code generation with native LLVM performance and gate-backed public claims.">
+  <meta name="description" content="Vais is a systems programming language designed for AI code generation with native LLVM performance and evidence-scoped public claims.">
   <meta property="og:title" content="Vais - AI-Optimized Systems Programming Language">
-  <meta property="og:description" content="Canonical syntax, LLVM backend, type inference, and gate-backed public claims. Write clear Vais, get native performance.">
+  <meta property="og:description" content="Canonical syntax, LLVM backend, type inference, and evidence-scoped public claims. Write clear Vais, get native performance.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="/logo-icon.png">
   <meta property="og:url" content="https://vaislang.dev/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Vais - AI-Optimized Systems Programming Language">
-  <meta name="twitter:description" content="Canonical syntax, LLVM backend, type inference, and gate-backed public claims. Write clear Vais, get native performance.">
+  <meta name="twitter:description" content="Canonical syntax, LLVM backend, type inference, and evidence-scoped public claims. Write clear Vais, get native performance.">
   <meta name="twitter:image" content="/logo-icon.png">
   <link rel="canonical" href="https://vaislang.dev/">
   <link rel="icon" type="image/png" href="/logo-icon.png">
@@ -61,7 +61,7 @@
     <div class="hero-bg"></div>
     <div class="container">
       <div class="hero-content">
-        <div class="hero-badge" data-i18n="hero.badge">Certified Core + Promoted Runtime Gates</div>
+        <div class="hero-badge" data-i18n="hero.badge">Certified Core + Scoped Evidence</div>
         <h1 class="hero-title" data-i18n="hero.title" data-i18n-html>
           Write <span class="gradient-text">clear Vais</span>,<br>
           get <span class="gradient-text">native performance</span>
@@ -125,9 +125,9 @@
   <!-- Token Comparison Section -->
   <section class="compare" id="compare">
     <div class="container">
-      <h2 class="section-title" data-i18n="compare.title">Canonical Syntax, Gate-Backed Claims</h2>
+      <h2 class="section-title" data-i18n="compare.title">Canonical Syntax, Evidence-Scoped Claims</h2>
       <p class="section-subtitle" data-i18n="compare.subtitle" data-i18n-html>
-        Step 19 retired the old single-letter keyword forms. Current public claims are tied to canonical syntax and named gates, including integrity, package, runtime, full-build, and product schema checks.
+        Step 19 retired the old single-letter keyword forms. Public claims now distinguish main-reproducible gates from integration evidence that is pending main gate port.
       </p>
       <div class="compare-grid">
         <!-- Vais (always visible) -->
@@ -242,38 +242,38 @@
         </div>
       </div>
       <div class="compare-bar-section">
-        <h3 class="compare-bar-title" data-i18n="compare.barTitle">Gate Snapshot — 2026-05-12</h3>
+        <h3 class="compare-bar-title" data-i18n="compare.barTitle">Evidence Snapshot — 2026-05-12</h3>
         <div class="compare-bars">
           <div class="bar-item">
-            <span class="bar-label">Integrity</span>
+            <span class="bar-label">Integrity evidence</span>
             <div class="bar-track">
               <div class="bar-fill bar-vais" style="width: 100%"></div>
             </div>
             <span class="bar-value">OK</span>
           </div>
           <div class="bar-item">
-            <span class="bar-label">VaisDB runtime</span>
+            <span class="bar-label">VaisDB runtime evidence</span>
             <div class="bar-track">
               <div class="bar-fill bar-python" style="width: 100%"></div>
             </div>
             <span class="bar-value">34/34</span>
           </div>
           <div class="bar-item">
-            <span class="bar-label">Server runtime</span>
+            <span class="bar-label">Server runtime evidence</span>
             <div class="bar-track">
               <div class="bar-fill bar-go" style="width: 100%"></div>
             </div>
             <span class="bar-value">20/20</span>
           </div>
           <div class="bar-item">
-            <span class="bar-label">Web full build</span>
+            <span class="bar-label">Web full-build evidence</span>
             <div class="bar-track">
               <div class="bar-fill bar-rust" style="width: 100%"></div>
             </div>
             <span class="bar-value">24/24</span>
           </div>
           <div class="bar-item">
-            <span class="bar-label">Product schema</span>
+            <span class="bar-label">Product schema evidence</span>
             <div class="bar-track">
               <div class="bar-fill bar-c" style="width: 100%"></div>
             </div>
@@ -281,7 +281,7 @@
           </div>
         </div>
         <p style="color: var(--text-muted); font-size: 0.85rem; margin-top: 0.75rem; text-align: center;" data-i18n="compare.barNote" data-i18n-html>
-          Baseline is generated from the current integrity manifest: cross-package schema 15/15 and multi-domain product schema 9/9 are locked gates.
+          Counts are integration evidence from the gate branch. The public main branch currently enforces wording/build boundaries; aggregate gate and product fixtures are pending main port.
         </p>
       </div>
     </div>
@@ -431,7 +431,7 @@
     <div class="container">
       <span class="section-badge" data-i18n="ecosystem.badge">Promoted Gates</span>
       <h2 class="section-title" data-i18n="ecosystem.title">Full-Stack Vais Ecosystem</h2>
-      <p class="section-subtitle" data-i18n="ecosystem.subtitle" data-i18n-html>Database, server, and web packages are tracked by explicit package, runtime, unit, full-build, cross-package schema, and shared-schema product gates. They are not presented as product-complete v1 releases.</p>
+      <p class="section-subtitle" data-i18n="ecosystem.subtitle" data-i18n-html>Database, server, and web packages are tracked by explicit package, runtime, unit, full-build, cross-package schema, and shared-schema product evidence. Main-branch aggregate gate porting is still pending.</p>
 
       <div class="vaisx-grid">
         <div class="vaisx-card">
@@ -442,12 +442,12 @@
         <div class="vaisx-card">
           <div class="vaisx-card-icon">🚀</div>
           <h3 data-i18n="ecosystem.server.title">vais-server — HTTP Framework</h3>
-          <p data-i18n="ecosystem.server.description">HTTP framework workbench with server runtime smoke 20/20. Broader REST, GraphQL, WebSocket, auth, and deployment guarantees require dedicated gates.</p>
+          <p data-i18n="ecosystem.server.description">HTTP framework workbench with server runtime integration evidence 20/20. Broader REST, GraphQL, WebSocket, auth, and deployment guarantees require dedicated gates.</p>
         </div>
         <div class="vaisx-card">
           <div class="vaisx-card-icon">🌐</div>
           <h3 data-i18n="ecosystem.vaisweb.title">vais-web (VaisX) — Web Framework</h3>
-          <p data-i18n="ecosystem.vaisweb.description">Web framework workbench with runtime smoke 61/77, unit 390/390, ecosystem package tests 3272/3272, full-build 24/24, and shared-schema product gate 9/9. Size claims require a size gate.</p>
+          <p data-i18n="ecosystem.vaisweb.description">Web framework workbench with runtime smoke evidence 61/77, unit 390/390, ecosystem package tests 3272/3272, full-build 24/24, and shared-schema product evidence 9/9. Size claims require a size gate.</p>
         </div>
       </div>
 

--- a/website/public/locales/en.json
+++ b/website/public/locales/en.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Vais - AI-Optimized Systems Programming Language",
-    "description": "Vais is a systems programming language designed for AI code generation with native LLVM performance and gate-backed public claims."
+    "description": "Vais is a systems programming language designed for AI code generation with native LLVM performance and evidence-scoped public claims."
   },
   "nav": {
     "compare": "Gates",
@@ -13,19 +13,19 @@
     "blog": "Blog"
   },
   "hero": {
-    "badge": "Certified Core + Promoted Runtime Gates",
+    "badge": "Certified Core + Scoped Evidence",
     "title": "Write <span class=\"gradient-text\">clear Vais</span>,<br>get <span class=\"gradient-text\">native performance</span>",
-    "subtitle": "Vais (Vibe AI Language for Systems) is a systems programming language optimized for AI code generation. The current public baseline is a certified Core compiler plus named promoted runtime gates.",
+    "subtitle": "Vais (Vibe AI Language for Systems) is a systems programming language optimized for AI code generation. The current public baseline separates main-reproducible gates from integration evidence pending main port.",
     "tryBrowser": "Try in Browser",
     "install": "brew install vais"
   },
   "compare": {
-    "title": "Canonical Syntax, Gate-Backed Claims",
-    "subtitle": "Step 19 retired the old single-letter keyword forms. Current public claims are tied to canonical syntax and named gates, including integrity, package, runtime, full-build, and product schema checks.",
+    "title": "Canonical Syntax, Evidence-Scoped Claims",
+    "subtitle": "Step 19 retired the old single-letter keyword forms. Public claims now distinguish main-reproducible gates from integration evidence that is pending main gate port.",
     "vais": "Vais",
     "tokens": "tokens",
-    "barTitle": "Gate Snapshot — 2026-05-12",
-    "barNote": "Baseline is generated from the current integrity manifest: cross-package schema 15/15 and multi-domain product schema 9/9 are locked gates."
+    "barTitle": "Evidence Snapshot — 2026-05-12",
+    "barNote": "Counts are integration evidence from the gate branch. The public main branch currently enforces wording/build boundaries; aggregate gate and product fixtures are pending main port."
   },
   "performance": {
     "title": "Native Performance",
@@ -107,7 +107,7 @@
   "vaisx": {
     "badge": "New",
     "title": "Build Web Apps with Vais",
-    "subtitle": "VaisX is the Vais web framework workbench. Current public claims are tied to promoted runtime, unit, package, full-build, and shared-schema product gates.",
+    "subtitle": "VaisX is the Vais web framework workbench. Current public claims distinguish main-reproducible gates from integration evidence pending main port.",
     "compiler": {
       "title": "Compile-Time Reactivity",
       "description": "Reactive state analysis and DOM update generation are active implementation surfaces verified only where named gates cover them."
@@ -117,8 +117,8 @@
       "description": "File-based routing and SSR/SSG modules exist; promoted behavior is documented by the current Vais Web gates."
     },
     "runtime": {
-      "title": "Promoted Runtime Gates",
-      "description": "The current Vais Web baseline is runtime smoke 61/77, unit 390/390, package tests 3272/3272, full-build 24/24, and shared-schema product gate 9/9. Size claims require a size gate."
+      "title": "Runtime Evidence",
+      "description": "Current Vais Web integration evidence is runtime smoke 61/77, unit 390/390, package tests 3272/3272, full-build 24/24, and shared-schema product evidence 9/9. Size claims require a size gate."
     },
     "learnMore": "Learn More",
     "github": "GitHub",

--- a/website/public/locales/ja.json
+++ b/website/public/locales/ja.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Vais - AI最適化システムプログラミング言語",
-    "description": "Vais は native LLVM performance と gate-backed public claims を持つ、AI code generation 向け systems programming language です。"
+    "description": "Vais は native LLVM performance と evidence-scoped public claims を持つ、AI code generation 向け systems programming language です。"
   },
   "nav": {
     "compare": "Gates",
@@ -13,19 +13,19 @@
     "blog": "ブログ"
   },
   "hero": {
-    "badge": "Certified Core + Promoted Runtime Gates",
+    "badge": "Certified Core + Scoped Evidence",
     "title": "<span class=\"gradient-text\">clear Vais</span> を書き、<br><span class=\"gradient-text\">native performance</span> を得る",
-    "subtitle": "Vais（Vibe AI Language for Systems）は、AIコード生成に最適化されたシステムプログラミング言語です。現在の公開基準は certified Core compiler と明示された promoted runtime gates です。",
+    "subtitle": "Vais（Vibe AI Language for Systems）は、AIコード生成に最適化されたシステムプログラミング言語です。現在の公開基準は main-reproducible gates と main port 待ちの integration evidence を区別します。",
     "tryBrowser": "ブラウザで試す",
     "install": "brew install vais"
   },
   "compare": {
-    "title": "Canonical Syntax, Gate-Backed Claims",
-    "subtitle": "Step 19 で旧 single-letter keyword form は削除されました。現在の公開 claim は canonical syntax と integrity、package、runtime、full-build、product schema などの named gates に紐づきます。",
+    "title": "Canonical Syntax, Evidence-Scoped Claims",
+    "subtitle": "Step 19 で旧 single-letter keyword form は削除されました。公開 claim は main-reproducible gates と main gate port 待ちの integration evidence を区別します。",
     "vais": "Vais",
     "tokens": "トークン",
-    "barTitle": "Gate Snapshot — 2026-05-12",
-    "barNote": "Baseline は現在の integrity manifest から生成されます。cross-package schema 15/15 と multi-domain product schema 9/9 が locked gate です。"
+    "barTitle": "Evidence Snapshot — 2026-05-12",
+    "barNote": "数値は gate branch の integration evidence です。public main branch は現在 wording/build boundary を強制し、aggregate gate と product fixture は main port 待ちです。"
   },
   "performance": {
     "title": "ネイティブパフォーマンス",
@@ -107,7 +107,7 @@
   "vaisx": {
     "badge": "新機能",
     "title": "VaisでWebアプリを構築",
-    "subtitle": "VaisX は Vais web framework workbench です。現在の公開 claim は promoted runtime、unit、package、full-build、shared-schema product gates に紐づきます。",
+    "subtitle": "VaisX は Vais web framework workbench です。現在の公開 claim は main-reproducible gates と main port 待ちの integration evidence を区別します。",
     "compiler": {
       "title": "コンパイル時リアクティビティ",
       "description": "Reactive state analysis と DOM update generation は named gates が覆盖する範囲でのみ検証された implementation surface です。"
@@ -117,8 +117,8 @@
       "description": "File-based routing と SSR/SSG module は存在します。promoted behavior は現在の Vais Web gate で判断します。"
     },
     "runtime": {
-      "title": "Promoted Runtime Gates",
-      "description": "現在の Vais Web baseline は runtime smoke 61/77、unit 390/390、package tests 3272/3272、full-build 24/24、shared-schema product gate 9/9 です。Size claim には size gate が必要です。"
+      "title": "Runtime Evidence",
+      "description": "現在の Vais Web integration evidence は runtime smoke 61/77、unit 390/390、package tests 3272/3272、full-build 24/24、shared-schema product evidence 9/9 です。Size claim には size gate が必要です。"
     },
     "learnMore": "詳しく見る",
     "github": "GitHub",

--- a/website/public/locales/ko.json
+++ b/website/public/locales/ko.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Vais - AI 최적화 시스템 프로그래밍 언어",
-    "description": "Vais는 네이티브 LLVM 성능과 gate-backed 공개 claim을 갖춘 AI 코드 생성용 시스템 프로그래밍 언어입니다."
+    "description": "Vais는 네이티브 LLVM 성능과 evidence-scoped 공개 claim을 갖춘 AI 코드 생성용 시스템 프로그래밍 언어입니다."
   },
   "nav": {
     "compare": "게이트",
@@ -13,19 +13,19 @@
     "blog": "블로그"
   },
   "hero": {
-    "badge": "Certified Core + Promoted Runtime Gates",
+    "badge": "Certified Core + Scoped Evidence",
     "title": "<span class=\"gradient-text\">명확한 Vais</span>를 작성하고,<br><span class=\"gradient-text\">네이티브 성능</span>을 얻으세요",
-    "subtitle": "Vais (Vibe AI Language for Systems)는 AI 코드 생성에 최적화된 시스템 프로그래밍 언어입니다. 현재 공개 기준은 certified Core compiler와 명시된 promoted runtime gate입니다.",
+    "subtitle": "Vais (Vibe AI Language for Systems)는 AI 코드 생성에 최적화된 시스템 프로그래밍 언어입니다. 현재 공개 기준은 main-reproducible gate와 main port 대기 중인 integration evidence를 구분합니다.",
     "tryBrowser": "브라우저에서 시도하기",
     "install": "brew install vais"
   },
   "compare": {
-    "title": "Canonical 문법과 Gate-backed Claim",
-    "subtitle": "Step 19에서 기존 single-letter keyword form은 제거되었습니다. 현재 공개 claim은 canonical 문법과 integrity, package, runtime, full-build, product schema 같은 명시 gate에 묶입니다.",
+    "title": "Canonical 문법과 Evidence-scoped Claim",
+    "subtitle": "Step 19에서 기존 single-letter keyword form은 제거되었습니다. 공개 claim은 main에서 재현되는 gate와 main gate port 대기 중인 integration evidence를 구분합니다.",
     "vais": "Vais",
     "tokens": "토큰",
-    "barTitle": "Gate Snapshot — 2026-05-12",
-    "barNote": "Baseline은 현재 integrity manifest 기준입니다. cross-package schema 15/15와 multi-domain product schema 9/9가 locked gate입니다."
+    "barTitle": "Evidence Snapshot — 2026-05-12",
+    "barNote": "수치는 gate branch의 integration evidence입니다. public main branch는 현재 wording/build boundary를 강제하며 aggregate gate와 product fixture는 main port 대기 중입니다."
   },
   "performance": {
     "title": "네이티브 성능",
@@ -107,7 +107,7 @@
   "vaisx": {
     "badge": "신규",
     "title": "Vais로 웹 앱 만들기",
-    "subtitle": "VaisX는 Vais web framework workbench입니다. 현재 공개 claim은 runtime, unit, package, full-build, shared-schema product gate에 묶입니다.",
+    "subtitle": "VaisX는 Vais web framework workbench입니다. 현재 공개 claim은 main-reproducible gate와 main port 대기 중인 integration evidence를 구분합니다.",
     "compiler": {
       "title": "컴파일 타임 반응성",
       "description": "Reactive state 분석과 DOM update generation은 명시된 gate가 덮는 범위에서만 검증된 구현 표면입니다."
@@ -117,8 +117,8 @@
       "description": "File-based routing과 SSR/SSG module은 존재합니다. promoted behavior는 현재 Vais Web gate 기준입니다."
     },
     "runtime": {
-      "title": "Promoted Runtime Gates",
-      "description": "현재 Vais Web baseline은 runtime smoke 61/77, unit 390/390, package tests 3272/3272, full-build 24/24, shared-schema product gate 9/9입니다. Size claim은 size gate가 필요합니다."
+      "title": "Runtime Evidence",
+      "description": "현재 Vais Web integration evidence는 runtime smoke 61/77, unit 390/390, package tests 3272/3272, full-build 24/24, shared-schema product evidence 9/9입니다. Size claim은 size gate가 필요합니다."
     },
     "learnMore": "더 알아보기",
     "github": "GitHub",

--- a/website/public/locales/zh.json
+++ b/website/public/locales/zh.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Vais - AI优化的系统编程语言",
-    "description": "Vais 是面向 AI code generation 的 systems programming language，提供 native LLVM performance 和 gate-backed public claims。"
+    "description": "Vais 是面向 AI code generation 的 systems programming language，提供 native LLVM performance 和 evidence-scoped public claims。"
   },
   "nav": {
     "compare": "Gates",
@@ -13,19 +13,19 @@
     "blog": "博客"
   },
   "hero": {
-    "badge": "Certified Core + Promoted Runtime Gates",
+    "badge": "Certified Core + Scoped Evidence",
     "title": "编写 <span class=\"gradient-text\">clear Vais</span>，<br>获得 <span class=\"gradient-text\">native performance</span>",
-    "subtitle": "Vais（Vibe AI Language for Systems）是为 AI 代码生成优化的系统编程语言。当前公开基线是 certified Core compiler 加上明确命名的 promoted runtime gates。",
+    "subtitle": "Vais（Vibe AI Language for Systems）是为 AI 代码生成优化的系统编程语言。当前公开基线区分 main-reproducible gates 与等待 main port 的 integration evidence。",
     "tryBrowser": "在浏览器中试用",
     "install": "brew install vais"
   },
   "compare": {
-    "title": "Canonical Syntax, Gate-Backed Claims",
-    "subtitle": "Step 19 已移除旧 single-letter keyword form。当前公开 claim 绑定到 canonical syntax 以及 integrity、package、runtime、full-build、product schema 等 named gates。",
+    "title": "Canonical Syntax, Evidence-Scoped Claims",
+    "subtitle": "Step 19 已移除旧 single-letter keyword form。公开 claim 区分 main-reproducible gates 与等待 main gate port 的 integration evidence。",
     "vais": "Vais",
     "tokens": "令牌",
-    "barTitle": "Gate Snapshot — 2026-05-12",
-    "barNote": "Baseline 来自当前 integrity manifest：cross-package schema 15/15 和 multi-domain product schema 9/9 是 locked gates。"
+    "barTitle": "Evidence Snapshot — 2026-05-12",
+    "barNote": "这些数字是 gate branch 的 integration evidence。public main branch 当前强制 wording/build boundary；aggregate gate 和 product fixture 仍在等待 main port。"
   },
   "performance": {
     "title": "原生性能",
@@ -107,7 +107,7 @@
   "vaisx": {
     "badge": "新功能",
     "title": "用 Vais 构建 Web 应用",
-    "subtitle": "VaisX 是 Vais web framework workbench。当前公开 claim 绑定到 promoted runtime、unit、package、full-build 和 shared-schema product gates。",
+    "subtitle": "VaisX 是 Vais web framework workbench。当前公开 claim 区分 main-reproducible gates 与等待 main port 的 integration evidence。",
     "compiler": {
       "title": "编译时响应性",
       "description": "Reactive state analysis 和 DOM update generation 是 implementation surfaces，只在 named gates 覆盖范围内验证。"
@@ -117,8 +117,8 @@
       "description": "File-based routing 和 SSR/SSG modules 存在；promoted behavior 以当前 Vais Web gates 为准。"
     },
     "runtime": {
-      "title": "Promoted Runtime Gates",
-      "description": "当前 Vais Web baseline 是 runtime smoke 61/77、unit 390/390、package tests 3272/3272、full-build 24/24、shared-schema product gate 9/9。Size claim 需要 size gate。"
+      "title": "Runtime Evidence",
+      "description": "当前 Vais Web integration evidence 是 runtime smoke 61/77、unit 390/390、package tests 3272/3272、full-build 24/24、shared-schema product evidence 9/9。Size claim 需要 size gate。"
     },
     "learnMore": "了解更多",
     "github": "GitHub",

--- a/website/vaisx/index.html
+++ b/website/vaisx/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>VaisX - Full-Stack Web Framework for Vais</title>
-  <meta name="description" content="VaisX is the Vais web framework workbench, tracked by promoted runtime, unit, package, and full-build gates.">
+  <meta name="description" content="VaisX is the Vais web framework workbench, described with evidence-scoped runtime, unit, package, and full-build claims.">
   <meta property="og:title" content="VaisX - Full-Stack Web Framework for Vais">
   <meta property="og:description" content="Compile-time reactivity, routing, and SSR surfaces tracked by explicit Vais Web gates.">
   <meta property="og:type" content="website">
@@ -297,7 +297,7 @@
         <span class="gradient-text">VaisX</span>
       </h1>
       <p class="vaisx-hero-subtitle" data-i18n="vaisx.subtitle">
-        VaisX is the Vais web framework workbench. Current public claims are tied to promoted runtime, unit, package, full-build, and shared-schema product gates.
+        VaisX is the Vais web framework workbench. Current public claims distinguish main-reproducible gates from integration evidence pending main port.
       </p>
       <div class="vaisx-hero-actions">
         <a href="#quickstart" class="btn btn-primary" data-i18n="vaisx.quickStart">Quick Start</a>
@@ -328,7 +328,7 @@
   <section class="vaisx-section" id="features">
     <div class="container">
       <h2 class="section-title" data-i18n="vaisx.title">Build Web Apps with Vais</h2>
-      <p class="section-subtitle" data-i18n="vaisx.subtitle" data-i18n-html>VaisX is the Vais web framework workbench. Current public claims are tied to promoted runtime, unit, package, full-build, and shared-schema product gates.</p>
+      <p class="section-subtitle" data-i18n="vaisx.subtitle" data-i18n-html>VaisX is the Vais web framework workbench. Current public claims distinguish main-reproducible gates from integration evidence pending main port.</p>
 
       <div class="vaisx-grid">
         <div class="vaisx-card">
@@ -343,8 +343,8 @@
         </div>
         <div class="vaisx-card">
           <div class="vaisx-card-icon">📦</div>
-          <h3 data-i18n="vaisx.runtime.title">Promoted Runtime Gates</h3>
-          <p data-i18n="vaisx.runtime.description">The current Vais Web baseline is runtime smoke 61/77, unit 390/390, package tests 3272/3272, full-build 24/24, and shared-schema product gate 9/9. Size claims require a size gate.</p>
+          <h3 data-i18n="vaisx.runtime.title">Runtime Evidence</h3>
+          <p data-i18n="vaisx.runtime.description">Current Vais Web integration evidence is runtime smoke 61/77, unit 390/390, package tests 3272/3272, full-build 24/24, and shared-schema product evidence 9/9. Size claims require a size gate.</p>
         </div>
       </div>
 


### PR DESCRIPTION
Summary:
- Split public status into main-reproducible gates vs integration evidence pending main port.
- Add a public claim evidence audit document.
- Update site/locales/claim guard to prevent non-main aggregate gates from being presented as main-reproducible.

Verification:
- node scripts/check-public-claims.mjs
- git diff --check
- cd website && npm run build

Note:
- This does not port scripts/check-integrity.sh or product/runtime fixtures to main. It makes the current evidence boundary explicit. The next work is porting the aggregate gate runner and fixtures from codex/ssr-json-grammar-gate.