### PR TITLE
Add main-scoped integrity runner

### DIFF
--- a/PUBLIC_STATUS.md
+++ b/PUBLIC_STATUS.md
@@ -30,6 +30,8 @@ The current `origin/main` tree directly enforces:
 - Browser-JS playground smoke gate: passed for parser + JavaScript codegen
   compile/execute in the browser; this is not a complete browser-only language
   implementation claim
+- Main-scoped integrity runner:
+  `bash scripts/check-integrity.sh`
 - `vaisc emit-ts` schema declaration tests:
   `cargo test --locked -p vaisc --test emit_ts_skeleton --test emit_ts_exhaustiveness`
 - Cross-package schema gate: `15/15` via
@@ -45,13 +47,13 @@ runtime coverage remains integration evidence below.
 
 The following counts are integration evidence from
 `codex/ssr-json-grammar-gate` and the local workspace as of 2026-05-12. They
-are public evidence, but the full aggregate runtime gate is not yet reproducible from `origin/main`
-until the aggregate integrity runner and ecosystem runtime gates are ported to
-main:
+are public evidence, but the full ecosystem runtime aggregate is not yet reproducible from `origin/main`
+until the DB/server/web runtime gates are ported to main:
 
 - Core compiler freeze bundle: passed
 - Downstream re-entry criteria: passed
-- Aggregate integrity runner: pending main port
+- Full ecosystem runtime aggregate runner: pending DB/server/web runtime main
+  port
 - Standard library package tests: `82/82`
 - VaisDB package tests: `261/261`
 - Backend package tests: `18/18`
@@ -81,8 +83,8 @@ The current baseline does not certify:
 - Broad external network reliability outside the promoted local smoke gates
 - Product-complete VaisDB, Vais Server, or Vais Web behavior
 - Complete API documentation for every standard-library module
-- Main-branch reproducibility for the full aggregate integrity gate until the
-  pending main-port work lands
+- Main-branch reproducibility for the full ecosystem runtime aggregate until
+  the pending DB/server/web runtime main-port work lands
 
 ## Public Wording Policy
 

--- a/docs/PUBLIC_CLAIM_EVIDENCE.md
+++ b/docs/PUBLIC_CLAIM_EVIDENCE.md
@@ -11,6 +11,7 @@ gate branch.
 | Claim area | Evidence in `origin/main` |
 |---|---|
 | Public wording boundary | `node scripts/check-public-claims.mjs` |
+| Main-scoped integrity runner | `bash scripts/check-integrity.sh` |
 | Website/docs/playground deployment | `.github/workflows/website.yml` |
 | Playground mode boundary | `scripts/check-playground-mode-contract.mjs` |
 | Browser-JS playground smoke | `scripts/check-browser-compiler-gate.mjs` |
@@ -30,12 +31,12 @@ These gates are present in the compiler tree and passed locally on
 ## Integration Evidence Pending Main Port
 
 The following counts are public evidence from `codex/ssr-json-grammar-gate`
-and the local multi-repository workspace, but the aggregate runner and
-ecosystem runtime gates are not yet present on `origin/main`.
+and the local multi-repository workspace, but the full DB/server/web runtime
+aggregate gates are not yet present on `origin/main`.
 
 | Claim area | Integration evidence | Main status |
 |---|---:|---|
-| Aggregate integrity runner | `scripts/check-integrity.sh` | Pending main port |
+| Full ecosystem runtime aggregate runner | `scripts/check-integrity.sh` on the gate branch | Pending DB/server/web runtime main port |
 | Std package codegen | `82/82` | Pending aggregate gate port |
 | VaisDB package codegen | `261/261` | Pending aggregate gate port |
 | Backend smoke | `18/18` | Pending aggregate gate port |
@@ -52,5 +53,6 @@ ecosystem runtime gates are not yet present on `origin/main`.
 ## Required Resolution
 
 Public pages may cite these numbers only as evidence-scoped claims. They must
-not imply that the full aggregate gate is reproducible from `origin/main` until
-the aggregate runner and ecosystem package gates are ported and passing there.
+not imply that the full ecosystem runtime aggregate is reproducible from
+`origin/main` until the DB/server/web runtime and ecosystem package gates are
+ported and passing there.

--- a/scripts/check-integrity.sh
+++ b/scripts/check-integrity.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# check-integrity.sh - Vais main-scoped integrity gate.
+#
+# This runner aggregates the integrity checks that are currently reproducible
+# from the main compiler tree plus the explicitly documented local workspace
+# schema gates. It is not the full DB/server/web runtime aggregate gate; those
+# promoted runtime counts remain integration evidence until their fixtures and
+# package gates are ported to main.
+#
+# Usage:
+#   bash scripts/check-integrity.sh
+#
+# Environment:
+#   VAISC=/path/to/vaisc                 compiler binary for schema gates
+#   TSC=/path/to/tsc                     TypeScript compiler for schema gates
+#   INTEGRITY_SKIP_BROWSER=1             skip browser playground smoke
+#   INTEGRITY_SKIP_SCHEMA=1              skip cross-package schema gates
+#   INTEGRITY_FULL_RUST=1                also run workspace clippy + tests
+#   INTEGRITY_CROSS_PACKAGE_SCHEMA_MIN=15
+#   INTEGRITY_MULTI_DOMAIN_PRODUCT_MIN=9
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+INTEGRITY_CROSS_PACKAGE_SCHEMA_MIN="${INTEGRITY_CROSS_PACKAGE_SCHEMA_MIN:-15}"
+INTEGRITY_MULTI_DOMAIN_PRODUCT_MIN="${INTEGRITY_MULTI_DOMAIN_PRODUCT_MIN:-9}"
+
+STATUS=0
+SUMMARY=()
+
+log() {
+  printf 'check-integrity: %s\n' "$*"
+}
+
+fail_gate() {
+  local name="$1"
+  local detail="$2"
+  STATUS=1
+  SUMMARY+=("${name}=fail")
+  printf 'check-integrity: FAIL: %s: %s\n' "${name}" "${detail}" >&2
+}
+
+pass_gate() {
+  local name="$1"
+  local detail="${2:-ok}"
+  SUMMARY+=("${name}=${detail}")
+  printf 'check-integrity: OK: %s: %s\n' "${name}" "${detail}"
+}
+
+run_gate() {
+  local name="$1"
+  shift
+  log "running ${name}..."
+  if "$@"; then
+    pass_gate "${name}"
+  else
+    fail_gate "${name}" "command exited non-zero"
+  fi
+}
+
+run_browser_compiler_gate() {
+  log "running browser_compiler build..."
+  if ! npm --prefix playground run browser-compiler:build; then
+    fail_gate "browser_compiler" "wasm build failed"
+    return
+  fi
+
+  log "running browser_compiler check..."
+  if node scripts/check-browser-compiler-gate.mjs; then
+    pass_gate "browser_compiler"
+  else
+    fail_gate "browser_compiler" "browser compiler smoke failed"
+  fi
+}
+
+parse_assertions() {
+  local log_file="$1"
+  local fallback_total="$2"
+  local line
+  line="$(grep -E 'GATE ASSERTIONS: [0-9]+/[0-9]+' "${log_file}" | tail -n 1 || true)"
+  if [[ "${line}" =~ GATE[[:space:]]ASSERTIONS:[[:space:]]([0-9]+)/([0-9]+) ]]; then
+    printf '%s %s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  else
+    printf '0 %s\n' "${fallback_total}"
+  fi
+}
+
+ensure_vaisc() {
+  if [[ -n "${VAISC:-}" ]]; then
+    if [[ -x "${VAISC}" ]]; then
+      return 0
+    fi
+    fail_gate "vaisc_binary" "VAISC is set but not executable: ${VAISC}"
+    return 1
+  fi
+
+  local debug_vaisc="${REPO_ROOT}/target/debug/vaisc"
+  if [[ ! -x "${debug_vaisc}" ]]; then
+    log "building vaisc for schema gates..."
+    if ! cargo build --locked -p vaisc; then
+      fail_gate "vaisc_binary" "cargo build -p vaisc failed"
+      return 1
+    fi
+  fi
+  VAISC="${debug_vaisc}"
+  export VAISC
+}
+
+run_cross_package_schema_gate() {
+  local gate="${REPO_ROOT}/tests/empirical/cross_package_schema/tests/gate.sh"
+  local log_file="/tmp/vais-cross-package-schema-main.log"
+  local positive_passed positive_total negative_passed negative_total passed total
+
+  : > "${log_file}"
+  if ! bash "${gate}" positive >> "${log_file}" 2>&1; then
+    fail_gate "cross_package_schema" "positive gate failed; see ${log_file}"
+    return
+  fi
+  read -r positive_passed positive_total < <(parse_assertions "${log_file}" 11)
+
+  : > "${log_file}.negative"
+  if ! bash "${gate}" negative >> "${log_file}.negative" 2>&1; then
+    cat "${log_file}.negative" >> "${log_file}"
+    fail_gate "cross_package_schema" "negative gate failed; see ${log_file}"
+    return
+  fi
+  read -r negative_passed negative_total < <(parse_assertions "${log_file}.negative" 4)
+  cat "${log_file}.negative" >> "${log_file}"
+
+  passed=$((positive_passed + negative_passed))
+  total=$((positive_total + negative_total))
+  if [[ "${passed}" -lt "${INTEGRITY_CROSS_PACKAGE_SCHEMA_MIN}" ]]; then
+    fail_gate "cross_package_schema" "${passed}/${total} below ${INTEGRITY_CROSS_PACKAGE_SCHEMA_MIN}; see ${log_file}"
+  else
+    pass_gate "cross_package_schema" "${passed}/${total}"
+  fi
+}
+
+run_multi_domain_product_gate() {
+  local gate="${REPO_ROOT}/tests/product/multi_domain_schema/tests/gate.sh"
+  local log_file="/tmp/vais-multi-domain-product-main.log"
+  local passed total
+
+  if ! bash "${gate}" > "${log_file}" 2>&1; then
+    fail_gate "multi_domain_product" "gate failed; see ${log_file}"
+    return
+  fi
+
+  read -r passed total < <(parse_assertions "${log_file}" 9)
+  if [[ "${passed}" -lt "${INTEGRITY_MULTI_DOMAIN_PRODUCT_MIN}" ]]; then
+    fail_gate "multi_domain_product" "${passed}/${total} below ${INTEGRITY_MULTI_DOMAIN_PRODUCT_MIN}; see ${log_file}"
+  else
+    pass_gate "multi_domain_product" "${passed}/${total}"
+  fi
+}
+
+run_gate "public_claims" node scripts/check-public-claims.mjs
+run_gate "playground_mode_contract" node scripts/check-playground-mode-contract.mjs
+
+if [[ "${INTEGRITY_SKIP_BROWSER:-0}" != "1" ]]; then
+  run_browser_compiler_gate
+fi
+
+run_gate "rustfmt" cargo fmt --check
+run_gate "emit_ts_tests" cargo test --locked -p vaisc --test emit_ts_skeleton --test emit_ts_exhaustiveness
+
+if [[ "${INTEGRITY_FULL_RUST:-0}" == "1" ]]; then
+  run_gate "workspace_clippy" cargo clippy --workspace --exclude vais-python --exclude vais-node -- -D warnings
+  run_gate "workspace_tests" cargo test --workspace --exclude vais-python --exclude vais-node
+fi
+
+if [[ "${INTEGRITY_SKIP_SCHEMA:-0}" != "1" ]]; then
+  if ensure_vaisc; then
+    run_cross_package_schema_gate
+    run_multi_domain_product_gate
+  fi
+fi
+
+printf '\n'
+if [[ "${STATUS}" -eq 0 ]]; then
+  if [[ "${INTEGRITY_SKIP_BROWSER:-0}" == "1" ]]; then
+    BROWSER_SUMMARY="browser=skipped"
+  else
+    BROWSER_SUMMARY="browser=ok"
+  fi
+  if [[ "${INTEGRITY_SKIP_SCHEMA:-0}" == "1" ]]; then
+    SCHEMA_SUMMARY="schema=skipped"
+  else
+    SCHEMA_SUMMARY="schema=ok"
+  fi
+  printf 'INTEGRITY OK: scope=main public_claims=ok playground=ok %s emit_ts=ok %s' \
+    "${BROWSER_SUMMARY}" "${SCHEMA_SUMMARY}"
+  if [[ "${INTEGRITY_FULL_RUST:-0}" == "1" ]]; then
+    printf ' rust_ci=ok'
+  fi
+  printf '\n'
+  printf 'INTEGRITY SUMMARY: %s\n' "${SUMMARY[*]}"
+  exit 0
+fi
+
+printf 'INTEGRITY FAILED: one or more main-scoped gates failed\n' >&2
+printf 'INTEGRITY SUMMARY: %s\n' "${SUMMARY[*]}" >&2
+exit 1

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -87,13 +87,13 @@ requireText(
 );
 requireText(
   publicStatus,
-  'Aggregate integrity runner: pending main port',
-  'aggregate integrity status must be explicit until the runner is on main',
+  'Main-scoped integrity runner:',
+  'main-scoped integrity runner must be named without promoting full ecosystem runtime scope',
 );
-forbidText(
+requireText(
   publicStatus,
-  'Final integrity gate: passed via `scripts/check-integrity.sh`',
-  'origin/main does not currently contain the aggregate integrity runner',
+  'Full ecosystem runtime aggregate runner: pending DB/server/web runtime main',
+  'full ecosystem runtime aggregate must remain explicitly pending',
 );
 requireText(
   publicStatus,


### PR DESCRIPTION
## Summary
- add a main-scoped `scripts/check-integrity.sh` that aggregates the currently main-reproducible public/schema/playground/compiler contract gates
- keep the full DB/server/web runtime aggregate explicitly scoped as pending main-port work
- update public-claim guard and evidence docs so the new runner cannot be mistaken for the full ecosystem runtime gate

## Verification
- `bash -n scripts/check-integrity.sh`
- `node scripts/check-public-claims.mjs`
- `git diff --check`
- `bash scripts/check-integrity.sh`
