### PR TITLE
types: make reference unification explicit

### DIFF
--- a/crates/vais-codegen/src/expr_helpers_data.rs
+++ b/crates/vais-codegen/src/expr_helpers_data.rs
@@ -10,6 +10,33 @@ use vais_ast::{Expr, Spanned};
 use vais_types::ResolvedType;
 
 impl CodeGenerator {
+    pub(crate) fn generate_field_base_expr(
+        &mut self,
+        obj: &Spanned<Expr>,
+        counter: &mut usize,
+    ) -> CodegenResult<(String, String)> {
+        // Field GEP needs the struct address. For `(*ref).field`, the deref's
+        // inner expression already is that address; emitting the deref load first
+        // would turn the base into a struct value.
+        if let Expr::Deref(inner) = &obj.node {
+            let inner_type = self.infer_expr_type(inner);
+            let derefs_to_named_struct = match &inner_type {
+                ResolvedType::Ref(target)
+                | ResolvedType::RefMut(target)
+                | ResolvedType::Pointer(target) => {
+                    matches!(target.as_ref(), ResolvedType::Named { .. })
+                }
+                _ => false,
+            };
+
+            if derefs_to_named_struct {
+                return self.generate_expr(inner, counter);
+            }
+        }
+
+        self.generate_expr(obj, counter)
+    }
+
     /// Register a ResolvedType for an index-load result based on its LLVM type string.
     ///
     /// This ensures downstream call-arg coercion (in generate_expr_call.rs) can detect
@@ -726,7 +753,7 @@ impl CodeGenerator {
             }
         }
 
-        let (obj_val, obj_ir) = self.generate_expr(obj, counter)?;
+        let (obj_val, obj_ir) = self.generate_field_base_expr(obj, counter)?;
         let mut ir = obj_ir;
 
         // Infer the type of the object expression (works for both Ident and nested Field)

--- a/crates/vais-codegen/src/generate_expr/ref_deref.rs
+++ b/crates/vais-codegen/src/generate_expr/ref_deref.rs
@@ -68,7 +68,7 @@ impl CodeGenerator {
         field: &Spanned<String>,
         counter: &mut usize,
     ) -> CodegenResult<Option<(String, String)>> {
-        let (obj_val, obj_ir) = self.generate_expr(obj, counter)?;
+        let (obj_val, obj_ir) = self.generate_field_base_expr(obj, counter)?;
         let mut ir = obj_ir;
         let obj_type = self.infer_expr_type(obj);
         let resolved_type = match &obj_type {

--- a/crates/vais-types/src/checker_expr/stmts.rs
+++ b/crates/vais-types/src/checker_expr/stmts.rs
@@ -116,17 +116,7 @@ impl TypeChecker {
                     ResolvedType::Unit
                 };
                 if let Some(expected) = self.current_fn_ret.clone() {
-                    // Auto-deref: if returning &T but expected is T, allow implicit deref
-                    let ret_type_deref = if let ResolvedType::Ref(inner) = &ret_type {
-                        if self.unify(&expected, inner).is_ok() {
-                            *inner.clone()
-                        } else {
-                            ret_type.clone()
-                        }
-                    } else {
-                        ret_type.clone()
-                    };
-                    self.unify(&expected, &ret_type_deref)?;
+                    self.unify(&expected, &ret_type)?;
                 }
                 // Return has "Never" type because execution doesn't continue past it
                 Ok(ResolvedType::Never)

--- a/crates/vais-types/src/checker_fn.rs
+++ b/crates/vais-types/src/checker_fn.rs
@@ -128,28 +128,20 @@ impl TypeChecker {
             }
         }
 
-        // Check return type (with auto-deref: &T unifies with T)
+        // Check return type. References must match references; returning a
+        // referenced value as T requires an explicit dereference expression.
         let expected_ret = self.current_fn_ret.clone().expect(
             "Internal compiler error: current_fn_ret should be set during function checking",
         );
-        let body_type_deref = if let ResolvedType::Ref(inner) = &body_type {
-            if self.unify(&expected_ret, inner).is_ok() {
-                *inner.clone()
-            } else {
-                body_type.clone()
-            }
-        } else {
-            body_type.clone()
-        };
         // main() with implicit i64 return: allow Unit body (auto-return 0)
         if f.name.node == "main"
             && ret_type_inferred
             && expected_ret == ResolvedType::I64
-            && body_type_deref == ResolvedType::Unit
+            && body_type == ResolvedType::Unit
         {
             // Skip unification — codegen will insert `ret i64 0`
         } else {
-            self.unify(&expected_ret, &body_type_deref)?;
+            self.unify(&expected_ret, &body_type)?;
         }
 
         // Phase 193 R-1b: finalize method instantiations that were deferred
@@ -183,7 +175,7 @@ impl TypeChecker {
 
         // Verify ImplTrait/DynTrait bounds: if return type is impl Trait or dyn Trait,
         // check that the concrete body type implements the required trait bounds.
-        self.verify_trait_type_bounds(&expected_ret, &body_type_deref);
+        self.verify_trait_type_bounds(&expected_ret, &body_type);
 
         // Resolve inferred return type: if return type was omitted, apply substitutions
         // to resolve the type variable to the concrete type from the body.
@@ -558,20 +550,12 @@ impl TypeChecker {
             FunctionBody::Block(stmts) => self.check_block(stmts)?,
         };
 
-        // Check return type (with auto-deref: &T unifies with T)
+        // Check return type. References must match references; returning a
+        // referenced value as T requires an explicit dereference expression.
         let expected_ret = self.current_fn_ret.clone().expect(
             "Internal compiler error: current_fn_ret should be set during function checking",
         );
-        let body_type_deref = if let ResolvedType::Ref(inner) = &body_type {
-            if self.unify(&expected_ret, inner).is_ok() {
-                *inner.clone()
-            } else {
-                body_type.clone()
-            }
-        } else {
-            body_type.clone()
-        };
-        self.unify(&expected_ret, &body_type_deref)?;
+        self.unify(&expected_ret, &body_type)?;
 
         // Resolve inferred parameter types for impl methods (same as check_function)
         if method

--- a/crates/vais-types/src/inference/unification.rs
+++ b/crates/vais-types/src/inference/unification.rs
@@ -243,6 +243,18 @@ impl TypeChecker {
                     Ok(())
                 }
             }
+            // Ref(Pointer<T>) ↔ Slice(T) auto-coercion for pointer-backed array literals.
+            // This is a narrow slice coercion, not a general &T ↔ T conversion.
+            (ResolvedType::Ref(inner), ResolvedType::Slice(elem))
+            | (ResolvedType::Slice(elem), ResolvedType::Ref(inner))
+                if matches!(inner.as_ref(), ResolvedType::Pointer(_)) =>
+            {
+                if let ResolvedType::Pointer(pointer_elem) = inner.as_ref() {
+                    self.unify(pointer_elem, elem)
+                } else {
+                    Ok(())
+                }
+            }
             // RefMut(Vec<T>) ↔ SliceMut(T) auto-coercion (Phase 163).
             (ResolvedType::RefMut(inner), ResolvedType::SliceMut(elem))
             | (ResolvedType::SliceMut(elem), ResolvedType::RefMut(inner))
@@ -250,6 +262,17 @@ impl TypeChecker {
             {
                 if let ResolvedType::Named { generics, .. } = inner.as_ref() {
                     self.unify(&generics[0], elem)
+                } else {
+                    Ok(())
+                }
+            }
+            // RefMut(Pointer<T>) ↔ SliceMut(T), same narrow pointer-backed slice coercion.
+            (ResolvedType::RefMut(inner), ResolvedType::SliceMut(elem))
+            | (ResolvedType::SliceMut(elem), ResolvedType::RefMut(inner))
+                if matches!(inner.as_ref(), ResolvedType::Pointer(_)) =>
+            {
+                if let ResolvedType::Pointer(pointer_elem) = inner.as_ref() {
+                    self.unify(pointer_elem, elem)
                 } else {
                     Ok(())
                 }
@@ -414,13 +437,8 @@ impl TypeChecker {
             // DynTrait: dyn Trait accepts any concrete type that implements the trait
             (ResolvedType::DynTrait { .. }, _) | (_, ResolvedType::DynTrait { .. }) => Ok(()),
             // ImplTrait / HigherKinded were removed in ROADMAP #18.
-            // Auto-deref: &T unifies with T (implicit dereference)
-            (ResolvedType::Ref(inner), other) | (other, ResolvedType::Ref(inner)) => {
-                self.unify(inner, other)
-            }
-            (ResolvedType::RefMut(inner), other) | (other, ResolvedType::RefMut(inner)) => {
-                self.unify(inner, other)
-            }
+            // Do not implicitly unify &T or &mut T with T. Value/reference
+            // conversion must be explicit at the expression boundary (`*ref`).
             _ => Err(TypeError::Mismatch {
                 expected: expected.to_string(),
                 found: found.to_string(),

--- a/crates/vais-types/tests/inference_unification_tests.rs
+++ b/crates/vais-types/tests/inference_unification_tests.rs
@@ -171,12 +171,35 @@ fn test_unify_result_generic() {
 }
 
 // ============================================================================
-// Unification — Ref / auto-deref
+// Unification — Ref
 // ============================================================================
 
 #[test]
-fn test_unify_ref_to_value() {
-    tc_ok("F test() -> i64 { x := 42; R x }");
+fn test_unify_ref_explicit_deref_to_value() {
+    tc_ok("F test() -> i64 { x := 42; r := &x; R *r }");
+}
+
+#[test]
+fn test_unify_ref_to_value_rejected_without_explicit_deref() {
+    tc_err("F test() -> i64 { x := 42; r := &x; R r }");
+}
+
+#[test]
+fn test_unify_ref_tail_expr_to_value_rejected_without_explicit_deref() {
+    tc_err("F test(x: i64) -> i64 = &x");
+}
+
+#[test]
+fn test_unify_ref_pointer_array_to_slice_allowed() {
+    tc_ok(
+        r#"
+        F first(xs: &[i64]) -> i64 = xs[0]
+        F test() -> i64 {
+            data := [1, 2, 3]
+            first(&data)
+        }
+    "#,
+    );
 }
 
 // ============================================================================

--- a/crates/vaisc/tests/e2e/phase91_lifetime.rs
+++ b/crates/vaisc/tests/e2e/phase91_lifetime.rs
@@ -210,16 +210,16 @@ F main() -> i64 = 42
     assert_exit_code(source, 42);
 }
 
-// REGRESSION(phase-124): literal returned from &i64 function promoted to global constant
 #[test]
-fn e2e_lifetime_no_ref_params_returns_ref() {
-    // No ref params, returns a ref → gets 'static from elision (valid for now)
-    // Literal 42 is promoted to a global constant so the returned i64* pointer is valid.
+fn e2e_lifetime_no_ref_params_returns_ref_rejected() {
+    // Strict reference semantics: returning a value from a reference-returning
+    // function is not an implicit literal promotion. The program must return
+    // an explicit reference with a valid lifetime.
     let source = r#"
 F get_ref() -> &i64 {
     42
 }
 F main() -> i64 = 42
 "#;
-    assert_exit_code(source, 42);
+    assert_compile_error(source);
 }

--- a/crates/vaisc/tests/e2e/phase91_lifetime.rs
+++ b/crates/vaisc/tests/e2e/phase91_lifetime.rs
@@ -133,6 +133,61 @@ F main() -> i64 = 42
     assert_exit_code(source, 42);
 }
 
+#[test]
+fn e2e_lifetime_explicit_deref_field_access() {
+    let source = r#"
+S Connection {
+    id: i64
+}
+
+F get_id(c: &Connection) -> i64 {
+    (*c).id
+}
+
+F main() -> i64 {
+    c := Connection { id: 42 }
+    get_id(&c)
+}
+"#;
+    assert_exit_code(source, 42);
+}
+
+#[test]
+fn e2e_lifetime_generic_option_ref_payload_explicit_deref_field() {
+    let source = r#"
+S Connection {
+    id: i64
+}
+
+E Option<T> {
+    Some(T),
+    None
+}
+
+F maybe(c: &Connection, flag: bool) -> Option<&Connection> {
+    I flag {
+        Some(c)
+    } E {
+        None
+    }
+}
+
+F get_id(c: &Connection) -> i64 {
+    (*c).id
+}
+
+F main() -> i64 {
+    c := Connection { id: 42 }
+    opt := maybe(&c, true)
+    M opt {
+        Some(conn) => get_id(conn),
+        None => 0
+    }
+}
+"#;
+    assert_exit_code(source, 42);
+}
+
 // ==================== Method Self Lifetime (Rule 3) ====================
 
 #[test]

--- a/selfhost/codegen.vais
+++ b/selfhost/codegen.vais
@@ -4792,7 +4792,7 @@ X CodeGenerator {
         candidates := malloc(max_candidates * 56)
         num_candidates: mut i64 = 0
 
-        @.inline_find_candidates(ir_data, ir_len, candidates, &num_candidates, max_candidates)
+        @.inline_find_candidates(ir_data, ir_len, candidates, (&num_candidates) as i64, max_candidates)
 
         I num_candidates == 0 {
             free(candidates)
@@ -4807,7 +4807,7 @@ X CodeGenerator {
         ci: mut i64 = 0
         L { I ci >= num_candidates { B }
             cand_ptr := candidates + ci * 56
-            new_data := @.inline_apply_candidate(cur_data, cur_len, cand_ptr, &inline_counter)
+            new_data := @.inline_apply_candidate(cur_data, cur_len, cand_ptr, (&inline_counter) as i64)
 
             I new_data != 0 {
                 new_len := load_i64(new_data + 8)  # stored at offset 8 by inline_apply
@@ -4998,7 +4998,7 @@ X CodeGenerator {
                         } EL { 0 }
 
                         # Track max register number
-                        @.inline_scan_max_reg(ir_data + ls, ll, &max_reg)
+                        @.inline_scan_max_reg(ir_data + ls, ll, (&max_reg) as i64)
 
                         # Check for non-void return
                         # "ret i64" → bytes 114 101 116 32 105 54 52
@@ -5163,7 +5163,7 @@ X CodeGenerator {
 
                 # Inline body with register offset
                 reg_offset := counter * (cand_max_reg + 1) + 100000
-                @.inline_emit_body(new_buf, &new_len, cand_body, cand_body_len, arg_values, cand_params, reg_offset, dest_reg, cand_ret)
+                @.inline_emit_body(new_buf, (&new_len) as i64, cand_body, cand_body_len, arg_values, cand_params, reg_offset, dest_reg, cand_ret)
 
                 # End comment
                 memcpy_str(new_buf + new_len, "  ; END INLINE\n", 15)


### PR DESCRIPTION
## Summary
- Remove the generic implicit `&T`/`&mut T` to `T` unification path and require explicit dereference at function and return-statement boundaries.
- Preserve the narrow pointer-backed array reference to slice coercion needed by existing slice call sites.
- Fix text-IR field access for explicit deref bases, including `Option<&Connection>` payload bindings that call through `(*ref).field`.
- Update selfhost raw pointer-to-i64 call sites and the lifetime regression expectation to make conversions explicit.

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p vais-types`
- `cargo test -p vais-types --test inference_unification_tests -- --nocapture test_unify_ref`
- `cargo test -p vaisc --test bootstrap_tests bootstrap_core_codegen_compiles -- --nocapture`
- `cargo test -p vaisc --test e2e phase190_vec_field_access -- --nocapture`
- `cargo test -p vaisc --test e2e e2e_lifetime_no_ref_params_returns_ref_rejected -- --nocapture`
- `cargo test -p vaisc --test e2e deref_field -- --nocapture`
- `cargo test -p vaisc --test e2e phase91_lifetime -- --nocapture`
- `cargo test -p vaisc`
- `cargo clippy -p vais-codegen -p vais-types -p vaisc --all-targets -- -D warnings`
- `git diff --check`