### PR TITLE
codegen: canonicalize enum layout

### DIFF
--- a/crates/vais-codegen/src/expr_helpers_misc.rs
+++ b/crates/vais-codegen/src/expr_helpers_misc.rs
@@ -8,6 +8,17 @@ use vais_ast::{Expr, Param, Spanned};
 use vais_types::ResolvedType;
 
 impl CodeGenerator {
+    fn enum_error_tag_for_type(&self, ty: &ResolvedType) -> i32 {
+        let variant = match ty {
+            ResolvedType::Optional(_) => "None",
+            ResolvedType::Result(_, _) => "Err",
+            ResolvedType::Named { name, .. } if name == "Option" => "None",
+            ResolvedType::Named { name, .. } if name == "Result" => "Err",
+            _ => "Err",
+        };
+        self.get_enum_variant_tag(variant)
+    }
+
     /// Resolve the poll function name for an await expression. Matches `Call`
     /// and `MethodCall` expressions whose callee names an async function; other
     /// expressions return `None` and the caller falls back to the generic path.
@@ -459,13 +470,21 @@ impl CodeGenerator {
             inner_val
         );
 
-        // Check if Err (tag != 0)
+        // Result propagates Err; Option propagates None. Tags are declaration-order.
+        let error_tag = self.enum_error_tag_for_type(&inner_type);
         let is_err = self.next_temp(counter);
         let err_label = self.next_label("try_err");
         let ok_label = self.next_label("try_ok");
         let merge_label = self.next_label("try_merge");
 
-        write_ir!(ir, "  {} = icmp ne {} {}, 0", is_err, tag_type, tag);
+        write_ir!(
+            ir,
+            "  {} = icmp eq {} {}, {}",
+            is_err,
+            tag_type,
+            tag,
+            error_tag
+        );
         write_ir!(
             ir,
             "  br i1 {}, label %{}, label %{}\n",
@@ -655,12 +674,20 @@ impl CodeGenerator {
             inner_val
         );
 
-        // Check if Err/None (tag != 0)
+        // Panic on Err/None. Tags are declaration-order.
+        let error_tag = self.enum_error_tag_for_type(&inner_type);
         let is_err = self.next_temp(counter);
         let err_label = self.next_label("unwrap_err");
         let ok_label = self.next_label("unwrap_ok");
 
-        write_ir!(ir, "  {} = icmp ne {} {}, 0", is_err, tag_type, tag);
+        write_ir!(
+            ir,
+            "  {} = icmp eq {} {}, {}",
+            is_err,
+            tag_type,
+            tag,
+            error_tag
+        );
         write_ir!(
             ir,
             "  br i1 {}, label %{}, label %{}\n",

--- a/crates/vais-codegen/src/function_gen/runtime.rs
+++ b/crates/vais-codegen/src/function_gen/runtime.rs
@@ -160,12 +160,15 @@ impl CodeGenerator {
 
         if self.types.enums.contains_key("Option") {
             // Base Option helpers for erased `%Option = { i32, { i64 } }`.
+            let some_tag = self.get_enum_variant_tag("Some");
+            let none_tag = self.get_enum_variant_tag("None");
+
             ir.push_str("\n; Base Option helper: is_some\n");
             ir.push_str("define weak_odr i64 @Option_is_some(%Option* %self) {\n");
             ir.push_str("entry:\n");
             ir.push_str("  %tag_ptr = getelementptr %Option, %Option* %self, i32 0, i32 0\n");
             ir.push_str("  %tag = load i32, i32* %tag_ptr\n");
-            ir.push_str("  %is_some = icmp ne i32 %tag, 0\n");
+            ir.push_str(&format!("  %is_some = icmp eq i32 %tag, {}\n", some_tag));
             ir.push_str("  %result = zext i1 %is_some to i64\n");
             ir.push_str("  ret i64 %result\n");
             ir.push_str("}\n");
@@ -175,7 +178,7 @@ impl CodeGenerator {
             ir.push_str("entry:\n");
             ir.push_str("  %tag_ptr = getelementptr %Option, %Option* %self, i32 0, i32 0\n");
             ir.push_str("  %tag = load i32, i32* %tag_ptr\n");
-            ir.push_str("  %is_none = icmp eq i32 %tag, 0\n");
+            ir.push_str(&format!("  %is_none = icmp eq i32 %tag, {}\n", none_tag));
             ir.push_str("  %result = zext i1 %is_none to i64\n");
             ir.push_str("  ret i64 %result\n");
             ir.push_str("}\n");
@@ -185,7 +188,7 @@ impl CodeGenerator {
             ir.push_str("entry:\n");
             ir.push_str("  %tag_ptr = getelementptr %Option, %Option* %self, i32 0, i32 0\n");
             ir.push_str("  %tag = load i32, i32* %tag_ptr\n");
-            ir.push_str("  %is_some = icmp ne i32 %tag, 0\n");
+            ir.push_str(&format!("  %is_some = icmp eq i32 %tag, {}\n", some_tag));
             ir.push_str("  br i1 %is_some, label %some, label %none\n");
             ir.push_str("some:\n");
             ir.push_str(

--- a/crates/vais-codegen/src/inkwell/gen_declaration.rs
+++ b/crates/vais-codegen/src/inkwell/gen_declaration.rs
@@ -151,15 +151,18 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
     pub(super) fn define_enum(&mut self, e: &ast::Enum) -> CodegenResult<StructType<'ctx>> {
         let enum_name = &e.name.node;
 
-        // If already defined, return existing
+        // If already defined and its variants were registered, return existing.
+        // Builtin erased Option/Result may be created first by type mapping; in
+        // that case we still need to register source-declared variant tags below.
         if let Some(existing) = self.generated_structs.get(enum_name) {
-            return Ok(*existing);
+            if self.enum_variants.keys().any(|(e, _)| e == enum_name) {
+                return Ok(*existing);
+            }
         }
 
-        // Validate variant count fits in i8 tag
-        if e.variants.len() > 255 {
+        if e.variants.len() > i32::MAX as usize {
             return Err(CodegenError::Unsupported(format!(
-                "Enum '{}' has {} variants (max 255 due to i8 tag)",
+                "Enum '{}' has {} variants (max i32::MAX due to i32 tag)",
                 enum_name,
                 e.variants.len()
             )));
@@ -223,15 +226,42 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             }
         }
 
-        // Create enum as struct: { i8 tag, i64 data }
-        // Must match the layout used in gen_expr.rs for variant construction
-        let enum_type = self.context.struct_type(
-            &[
-                self.context.i8_type().into(),
-                self.context.i64_type().into(),
-            ],
-            false,
-        );
+        let max_field_count = e
+            .variants
+            .iter()
+            .map(|variant| match &variant.fields {
+                ast::VariantFields::Unit => 0usize,
+                ast::VariantFields::Tuple(types) => types.len(),
+                ast::VariantFields::Struct(fields) => fields.len(),
+            })
+            .max()
+            .unwrap_or(0);
+
+        // Create enum as a named struct matching the text backend:
+        // unit-only: `%E = type { i32 }`
+        // payload:   `%E = type { i32, { i64, ... } }`
+        let enum_type = if let Some(existing) = self.generated_structs.get(enum_name).copied() {
+            existing
+        } else if let Some(existing) = self.type_mapper.get_registered_struct(enum_name) {
+            existing
+        } else {
+            self.context.opaque_struct_type(enum_name)
+        };
+
+        if enum_type.count_fields() == 0 {
+            if max_field_count == 0 {
+                enum_type.set_body(&[self.context.i32_type().into()], false);
+            } else {
+                let payload_fields: Vec<_> = (0..max_field_count)
+                    .map(|_| self.context.i64_type().into())
+                    .collect();
+                let payload_type = self.context.struct_type(&payload_fields, false);
+                enum_type.set_body(
+                    &[self.context.i32_type().into(), payload_type.into()],
+                    false,
+                );
+            }
+        }
 
         self.generated_structs.insert(enum_name.clone(), enum_type);
         self.type_mapper.register_struct(enum_name, enum_type);

--- a/crates/vais-codegen/src/inkwell/gen_expr/call.rs
+++ b/crates/vais-codegen/src/inkwell/gen_expr/call.rs
@@ -142,104 +142,41 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             "load_byte" => return self.generate_load_byte(args),
             "store_f64" => return self.generate_store_f64(args),
             "load_f64" => return self.generate_load_f64(args),
-            // Option constructors: Some(val) -> { i8 tag=1, i64 data=val }
+            // Option constructors: Some(val) -> canonical `%Option`.
             "Some" => {
-                let enum_type = self.context.struct_type(
-                    &[
-                        self.context.i8_type().into(),
-                        self.context.i64_type().into(),
-                    ],
-                    false,
-                );
-                let data_val = if args.is_empty() {
-                    self.context.i64_type().const_int(0, false)
+                let enum_type = self.erased_enum_type("Option");
+                let tag = self.get_enum_variant_tag("Some");
+                let payload_slots = if args.is_empty() {
+                    Vec::new()
                 } else {
                     let v = self.generate_expr(&args[0].node)?;
-                    self.coerce_to_i64(v)?
+                    vec![self.erase_enum_payload_to_i64(v, "some_data")?]
                 };
-                let mut val = enum_type.get_undef();
-                val = self
-                    .builder
-                    .build_insert_value(
-                        val,
-                        self.context.i8_type().const_int(1, false),
-                        0,
-                        "some_tag",
-                    )
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                    .into_struct_value();
-                val = self
-                    .builder
-                    .build_insert_value(val, data_val, 1, "some_data")
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                    .into_struct_value();
-                return Ok(val.into());
+                return self.build_erased_enum_value(enum_type, tag, &payload_slots, "some");
             }
-            // Result constructors: Ok(val) -> { i8 tag=0, i64 data=val }
+            // Result constructors: Ok(val) -> canonical `%Result`.
             "Ok" => {
-                let enum_type = self.context.struct_type(
-                    &[
-                        self.context.i8_type().into(),
-                        self.context.i64_type().into(),
-                    ],
-                    false,
-                );
-                let data_val = if args.is_empty() {
-                    self.context.i64_type().const_int(0, false)
+                let enum_type = self.erased_enum_type("Result");
+                let tag = self.get_enum_variant_tag("Ok");
+                let payload_slots = if args.is_empty() {
+                    Vec::new()
                 } else {
                     let v = self.generate_expr(&args[0].node)?;
-                    self.coerce_to_i64(v)?
+                    vec![self.erase_enum_payload_to_i64(v, "ok_data")?]
                 };
-                let mut val = enum_type.get_undef();
-                val = self
-                    .builder
-                    .build_insert_value(
-                        val,
-                        self.context.i8_type().const_int(0, false),
-                        0,
-                        "ok_tag",
-                    )
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                    .into_struct_value();
-                val = self
-                    .builder
-                    .build_insert_value(val, data_val, 1, "ok_data")
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                    .into_struct_value();
-                return Ok(val.into());
+                return self.build_erased_enum_value(enum_type, tag, &payload_slots, "ok");
             }
-            // Err(val) -> { i8 tag=1, i64 data=val }
+            // Err(val) -> canonical `%Result`.
             "Err" => {
-                let enum_type = self.context.struct_type(
-                    &[
-                        self.context.i8_type().into(),
-                        self.context.i64_type().into(),
-                    ],
-                    false,
-                );
-                let data_val = if args.is_empty() {
-                    self.context.i64_type().const_int(0, false)
+                let enum_type = self.erased_enum_type("Result");
+                let tag = self.get_enum_variant_tag("Err");
+                let payload_slots = if args.is_empty() {
+                    Vec::new()
                 } else {
                     let v = self.generate_expr(&args[0].node)?;
-                    self.coerce_to_i64(v)?
+                    vec![self.erase_enum_payload_to_i64(v, "err_data")?]
                 };
-                let mut val = enum_type.get_undef();
-                val = self
-                    .builder
-                    .build_insert_value(
-                        val,
-                        self.context.i8_type().const_int(1, false),
-                        0,
-                        "err_tag",
-                    )
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                    .into_struct_value();
-                val = self
-                    .builder
-                    .build_insert_value(val, data_val, 1, "err_data")
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                    .into_struct_value();
-                return Ok(val.into());
+                return self.build_erased_enum_value(enum_type, tag, &payload_slots, "err");
             }
             "puts_ptr" => {
                 // puts_ptr(i64) -> i32: convert i64 to ptr then call puts
@@ -479,189 +416,22 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
                 .enum_variants
                 .iter()
                 .find(|((_, v_name), _)| v_name == &fn_name)
-                .map(|((_, _), tag)| *tag);
+                .map(|((enum_name, _), tag)| (enum_name.clone(), *tag));
 
-            if let Some(tag) = is_enum_variant {
-                // Build enum value: { i8 tag, i64 data }
-                let enum_type = self.context.struct_type(
-                    &[
-                        self.context.i8_type().into(),
-                        self.context.i64_type().into(),
-                    ],
-                    false,
-                );
-                let data_val = if args.is_empty() {
-                    self.context.i64_type().const_int(0, false)
-                } else if args.len() > 1 {
-                    // Multi-field tuple variant: pack all fields into an anonymous struct,
-                    // heap-allocate, and store pointer in i64 data slot.
-                    let field_vals: Vec<BasicValueEnum<'ctx>> = args
-                        .iter()
-                        .map(|a| self.generate_expr(&a.node))
-                        .collect::<CodegenResult<Vec<_>>>()?;
-                    let field_tys: Vec<inkwell::types::BasicTypeEnum<'ctx>> =
-                        field_vals.iter().map(|v| v.get_type()).collect();
-                    let payload_ty = self.context.struct_type(&field_tys, false);
-                    let target_data = inkwell::targets::TargetData::create(
-                        &self.module.get_triple().as_str().to_string_lossy(),
+            if let Some((enum_name, tag)) = is_enum_variant {
+                let enum_type = self
+                    .generated_structs
+                    .get(&enum_name)
+                    .copied()
+                    .unwrap_or_else(|| self.erased_enum_type(&enum_name));
+                let mut payload_slots = Vec::with_capacity(args.len());
+                for (idx, arg) in args.iter().enumerate() {
+                    let payload = self.generate_expr(&arg.node)?;
+                    payload_slots.push(
+                        self.erase_enum_payload_to_i64(payload, &format!("variant_data_{}", idx))?,
                     );
-                    let size_bytes = target_data.get_store_size(&payload_ty);
-                    let i64_ty = self.context.i64_type();
-                    let i8_ptr_ty = self.context.i8_type().ptr_type(AddressSpace::default());
-                    // Always heap-alloc for multi-field (simpler than deciding per-size).
-                    let malloc_fn = self
-                        .module
-                        .get_function("malloc")
-                        .or_else(|| {
-                            let malloc_ty = i8_ptr_ty.fn_type(&[i64_ty.into()], false);
-                            Some(self.module.add_function("malloc", malloc_ty, None))
-                        })
-                        .unwrap();
-                    let size_val = i64_ty.const_int(size_bytes, false);
-                    let heap_ptr = self
-                        .builder
-                        .build_call(malloc_fn, &[size_val.into()], "variant_multi_heap")
-                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                        .try_as_basic_value()
-                        .basic()
-                        .unwrap()
-                        .into_pointer_value();
-                    let typed_ptr = self
-                        .builder
-                        .build_bit_cast(
-                            heap_ptr,
-                            payload_ty.ptr_type(AddressSpace::default()),
-                            "variant_multi_typed",
-                        )
-                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                        .into_pointer_value();
-                    // Build the payload struct and store it.
-                    let mut payload_val = payload_ty.get_undef();
-                    for (i, fv) in field_vals.iter().enumerate() {
-                        payload_val = self
-                            .builder
-                            .build_insert_value(
-                                payload_val,
-                                *fv,
-                                i as u32,
-                                &format!("variant_multi_field_{}", i),
-                            )
-                            .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                            .into_struct_value();
-                    }
-                    self.builder
-                        .build_store(typed_ptr, payload_val)
-                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
-                    // Record the payload struct type so pattern binding can recover field types.
-                    // Look up the enum name that owns this tag value.
-                    let owning_enum_name = self
-                        .enum_variants
-                        .iter()
-                        .find(|((_, v_name), t)| v_name == &fn_name && **t == tag)
-                        .map(|((e_name, _), _)| e_name.clone());
-                    if let Some(enum_name) = owning_enum_name {
-                        self.enum_variant_multi_payload_types
-                            .insert((enum_name, fn_name.clone()), payload_ty);
-                    }
-                    self.builder
-                        .build_ptr_to_int(heap_ptr, i64_ty, "variant_multi_data_as_i64")
-                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                } else {
-                    let v = self.generate_expr(&args[0].node)?;
-                    // Large struct (>8B) cannot fit in i64: heap-allocate and store pointer.
-                    // Small types (i64, f64, ptr, ≤8B struct) use bitcast/coerce_to_i64.
-                    if v.is_struct_value() {
-                        let struct_val = v.into_struct_value();
-                        let struct_ty = struct_val.get_type();
-                        let target_data = inkwell::targets::TargetData::create(
-                            &self.module.get_triple().as_str().to_string_lossy(),
-                        );
-                        let size_bytes = target_data.get_store_size(&struct_ty);
-                        if size_bytes > 8 {
-                            // Heap-allocate: malloc(size) → memcpy struct → ptrtoint to i64
-                            let i64_ty = self.context.i64_type();
-                            let i8_ptr_ty =
-                                self.context.i8_type().ptr_type(AddressSpace::default());
-                            // Call malloc(size)
-                            let malloc_fn = self
-                                .module
-                                .get_function("malloc")
-                                .or_else(|| {
-                                    let malloc_ty = i8_ptr_ty.fn_type(&[i64_ty.into()], false);
-                                    Some(self.module.add_function("malloc", malloc_ty, None))
-                                })
-                                .unwrap();
-                            let size_val = i64_ty.const_int(size_bytes, false);
-                            let heap_ptr = self
-                                .builder
-                                .build_call(malloc_fn, &[size_val.into()], "variant_heap")
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                                .try_as_basic_value()
-                                .basic()
-                                .unwrap()
-                                .into_pointer_value();
-                            // Store struct into heap memory
-                            let typed_ptr = self
-                                .builder
-                                .build_bit_cast(
-                                    heap_ptr,
-                                    struct_ty.ptr_type(AddressSpace::default()),
-                                    "variant_heap_typed",
-                                )
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                                .into_pointer_value();
-                            self.builder
-                                .build_store(typed_ptr, struct_val)
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
-                            // ptrtoint to i64 for enum data slot
-                            self.builder
-                                .build_ptr_to_int(heap_ptr, i64_ty, "variant_data_as_i64")
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                        } else {
-                            // Small struct (≤8B): bitcast via stack alloca to i64
-                            let i64_ty = self.context.i64_type();
-                            let tmp_alloca = self
-                                .builder
-                                .build_alloca(struct_ty, "variant_small_tmp")
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
-                            self.builder
-                                .build_store(tmp_alloca, struct_val)
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
-                            let i64_ptr = self
-                                .builder
-                                .build_bit_cast(
-                                    tmp_alloca,
-                                    i64_ty.ptr_type(AddressSpace::default()),
-                                    "variant_small_as_i64p",
-                                )
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                                .into_pointer_value();
-                            self.builder
-                                .build_load(i64_ty, i64_ptr, "variant_small_as_i64")
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                                .into_int_value()
-                        }
-                    } else {
-                        self.coerce_to_i64(v)?
-                    }
-                };
-                let mut val = enum_type.get_undef();
-                val = self
-                    .builder
-                    .build_insert_value(
-                        val,
-                        self.context.i8_type().const_int(tag as u64, false),
-                        0,
-                        "variant_tag",
-                    )
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                    .into_struct_value();
-                val = self
-                    .builder
-                    .build_insert_value(val, data_val, 1, "variant_data")
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                    .into_struct_value();
-                return Ok(val.into());
+                }
+                return self.build_erased_enum_value(enum_type, tag, &payload_slots, "variant");
             }
 
             // Collect all available function names for suggestions

--- a/crates/vais-codegen/src/inkwell/gen_expr/var.rs
+++ b/crates/vais-codegen/src/inkwell/gen_expr/var.rs
@@ -7,37 +7,11 @@ use crate::{CodegenError, CodegenResult};
 
 impl<'ctx> InkwellCodeGenerator<'ctx> {
     pub(super) fn generate_var(&mut self, name: &str) -> CodegenResult<BasicValueEnum<'ctx>> {
-        // Handle None as a built-in value: { i8 tag=0, i64 data=0 }
+        // Handle None as a built-in value using the canonical erased Option ABI.
         if name == "None" {
-            let enum_type = self.context.struct_type(
-                &[
-                    self.context.i8_type().into(),
-                    self.context.i64_type().into(),
-                ],
-                false,
-            );
-            let mut val = enum_type.get_undef();
-            val = self
-                .builder
-                .build_insert_value(
-                    val,
-                    self.context.i8_type().const_int(0, false),
-                    0,
-                    "none_tag",
-                )
-                .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                .into_struct_value();
-            val = self
-                .builder
-                .build_insert_value(
-                    val,
-                    self.context.i64_type().const_int(0, false),
-                    1,
-                    "none_data",
-                )
-                .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                .into_struct_value();
-            return Ok(val.into());
+            let enum_type = self.erased_enum_type("Option");
+            let tag = self.get_enum_variant_tag("None");
+            return self.build_erased_enum_value(enum_type, tag, &[], "none");
         }
 
         let result = self.locals.get(name);
@@ -60,38 +34,18 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             Ok(value)
         } else {
             // Check if this is an enum variant name (e.g., Red, Green, Blue)
-            for ((_, v_name), tag) in &self.enum_variants {
-                if v_name == name {
-                    let enum_type = self.context.struct_type(
-                        &[
-                            self.context.i8_type().into(),
-                            self.context.i64_type().into(),
-                        ],
-                        false,
-                    );
-                    let mut val = enum_type.get_undef();
-                    val = self
-                        .builder
-                        .build_insert_value(
-                            val,
-                            self.context.i8_type().const_int(*tag as u64, false),
-                            0,
-                            "variant_tag",
-                        )
-                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                        .into_struct_value();
-                    val = self
-                        .builder
-                        .build_insert_value(
-                            val,
-                            self.context.i64_type().const_int(0, false),
-                            1,
-                            "variant_data",
-                        )
-                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                        .into_struct_value();
-                    return Ok(val.into());
-                }
+            let variant = self
+                .enum_variants
+                .iter()
+                .find(|((_, v_name), _)| v_name == name)
+                .map(|((enum_name, _), tag)| (enum_name.clone(), *tag));
+            if let Some((enum_name, tag)) = variant {
+                let enum_type = self
+                    .generated_structs
+                    .get(&enum_name)
+                    .copied()
+                    .unwrap_or_else(|| self.erased_enum_type(&enum_name));
+                return self.build_erased_enum_value(enum_type, tag, &[], "variant");
             }
 
             // Check if this is a function name (function reference as variable)

--- a/crates/vais-codegen/src/inkwell/gen_match.rs
+++ b/crates/vais-codegen/src/inkwell/gen_match.rs
@@ -549,7 +549,7 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
                         .build_int_compare(
                             IntPredicate::EQ,
                             tag_val,
-                            self.context.i8_type().const_int(expected_tag as u64, false),
+                            tag_val.get_type().const_int(expected_tag as u64, false),
                             "variant_check",
                         )
                         .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
@@ -743,7 +743,7 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             }
             Pattern::Variant { name, fields: _ } => {
                 // Enum variant pattern: check the tag matches
-                // Enum is represented as { i8 tag, i64 data }
+                // Enum is represented as `{ i32 tag, { i64... } payload }`.
                 let struct_val = match_val.into_struct_value();
                 let tag_val = self
                     .builder
@@ -759,7 +759,7 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
                     .build_int_compare(
                         IntPredicate::EQ,
                         tag_val,
-                        self.context.i8_type().const_int(expected_tag as u64, false),
+                        tag_val.get_type().const_int(expected_tag as u64, false),
                         "variant_check",
                     )
                     .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
@@ -849,16 +849,23 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             }
             Pattern::Variant { name, fields } => {
                 // Bind variant fields.
-                // Enum is { i8 tag, i64 data } — the data field (index 1) holds the payload.
-                // For single-field variants the payload IS the value (or a pointer if the
-                // payload is a struct >8B that was heap-allocated by the constructor).
-                // For multi-field variants the payload is an anonymous struct; extract each
-                // sub-field with sequential build_extract_value calls.
+                // Enum is `{ i32 tag, { i64... } payload }`. Each variant field is
+                // erased into one i64 payload slot.
                 let struct_val = match_val.into_struct_value();
-                let data_val = self
-                    .builder
-                    .build_extract_value(struct_val, 1, "variant_data")
-                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
+                let payload_val = if struct_val.get_type().count_fields() > 1 {
+                    self.builder
+                        .build_extract_value(struct_val, 1, "variant_payload")
+                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
+                } else {
+                    self.context.i64_type().const_int(0, false).into()
+                };
+                let data_val = if payload_val.is_struct_value() {
+                    self.builder
+                        .build_extract_value(payload_val.into_struct_value(), 0, "variant_data")
+                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
+                } else {
+                    payload_val
+                };
 
                 // Look up whether this variant carries a struct payload.
                 // (enum_name unknown here — scan enum_variant_struct_types by variant name.)
@@ -925,11 +932,8 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
                             }
                         }
 
-                        // Non-struct payload (e.g. Circle(f64)): the enum data
-                        // slot stored the payload as i64 (floats bitcast, ints
-                        // widened). Recover the declared primitive type if we
-                        // have it recorded so the bound identifier has the
-                        // right LLVM type downstream.
+                        // Non-struct payload (e.g. Circle(f64)): recover the
+                        // declared type from the erased i64 payload slot.
                         let primitive_ty: Option<inkwell::types::BasicTypeEnum<'ctx>> = self
                             .enum_variant_primitive_payload_types
                             .iter()
@@ -937,41 +941,8 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
                             .map(|(_, ty)| *ty);
                         if let Some(decl_ty) = primitive_ty {
                             let data_i64 = data_val.into_int_value();
-                            let decoded: BasicValueEnum<'ctx> = if decl_ty.is_float_type() {
-                                self.builder
-                                    .build_bit_cast(
-                                        data_i64,
-                                        decl_ty.into_float_type(),
-                                        "variant_i64_to_f",
-                                    )
-                                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                            } else if decl_ty.is_int_type() {
-                                let target = decl_ty.into_int_type();
-                                if target.get_bit_width() == 64 {
-                                    data_i64.into()
-                                } else if target.get_bit_width() < 64 {
-                                    self.builder
-                                        .build_int_truncate(data_i64, target, "variant_i64_trunc")
-                                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                                        .into()
-                                } else {
-                                    self.builder
-                                        .build_int_s_extend(data_i64, target, "variant_i64_sext")
-                                        .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                                        .into()
-                                }
-                            } else if decl_ty.is_pointer_type() {
-                                self.builder
-                                    .build_int_to_ptr(
-                                        data_i64,
-                                        decl_ty.into_pointer_type(),
-                                        "variant_i64_to_ptr",
-                                    )
-                                    .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                                    .into()
-                            } else {
-                                data_val
-                            };
+                            let decoded =
+                                self.decode_enum_payload_slot(data_i64, decl_ty, "variant_slot")?;
                             self.generate_pattern_bindings(first_field, &decoded)?;
                             return Ok(());
                         }
@@ -979,9 +950,8 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
                         self.generate_pattern_bindings(first_field, &data_val)?;
                     }
                 } else {
-                    // Multi-field variant: the payload is packed into an anonymous struct
-                    // and stored on the heap. The enum's i64 data slot holds the heap ptr.
-                    // Look up the payload struct type recorded at construction time.
+                    // Multi-field variant: each erased payload slot corresponds to
+                    // the same-index declared field type recorded at enum declaration.
                     let multi_payload_ty: Option<inkwell::types::StructType<'ctx>> = self
                         .enum_variant_multi_payload_types
                         .iter()
@@ -989,28 +959,32 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
                         .map(|(_, ty)| *ty);
 
                     if let Some(payload_ty) = multi_payload_ty {
-                        // data_val is the i64 holding the heap pointer. inttoptr to struct*,
-                        // load the struct, then extract each field.
-                        let data_i64 = data_val.into_int_value();
-                        let ptr_ty = payload_ty.ptr_type(AddressSpace::default());
-                        let heap_ptr = self
-                            .builder
-                            .build_int_to_ptr(data_i64, ptr_ty, "variant_multi_ptr")
-                            .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
-                        let loaded_struct = self
-                            .builder
-                            .build_load(payload_ty, heap_ptr, "variant_multi_load")
-                            .map_err(|e| CodegenError::LlvmError(e.to_string()))?
-                            .into_struct_value();
+                        if !payload_val.is_struct_value() {
+                            if let Some(first_field) = fields.first() {
+                                self.generate_pattern_bindings(first_field, &data_val)?;
+                            }
+                            return Ok(());
+                        }
+
+                        let payload_struct = payload_val.into_struct_value();
                         for (idx, field_pat) in fields.iter().enumerate() {
-                            let sub_val = self
+                            let slot = self
                                 .builder
                                 .build_extract_value(
-                                    loaded_struct,
+                                    payload_struct,
                                     idx as u32,
-                                    &format!("variant_field_{}", idx),
+                                    &format!("variant_slot_{}", idx),
                                 )
-                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?;
+                                .map_err(|e| CodegenError::LlvmError(e.to_string()))?
+                                .into_int_value();
+                            let declared_ty = payload_ty
+                                .get_field_type_at_index(idx as u32)
+                                .unwrap_or_else(|| self.context.i64_type().into());
+                            let sub_val = self.decode_enum_payload_slot(
+                                slot,
+                                declared_ty,
+                                &format!("variant_field_{}", idx),
+                            )?;
                             self.generate_pattern_bindings(field_pat, &sub_val)?;
                         }
                     } else if data_val.is_struct_value() {

--- a/crates/vais-codegen/src/inkwell/gen_types.rs
+++ b/crates/vais-codegen/src/inkwell/gen_types.rs
@@ -77,6 +77,36 @@ fn convert_const_binop(op: &vais_ast::ConstBinOp) -> vais_types::ConstBinOp {
 }
 
 impl<'ctx> InkwellCodeGenerator<'ctx> {
+    fn enum_error_tag_for_expr(&self, expr: &Expr) -> i32 {
+        fn classify(ty: &ResolvedType) -> Option<&'static str> {
+            match ty {
+                ResolvedType::Optional(_) => Some("None"),
+                ResolvedType::Result(_, _) => Some("Err"),
+                ResolvedType::Named { name, .. } if name == "Option" => Some("None"),
+                ResolvedType::Named { name, .. } if name == "Result" => Some("Err"),
+                _ => None,
+            }
+        }
+
+        let variant = match expr {
+            Expr::Ident(name) => self.var_resolved_types.get(name).and_then(classify),
+            Expr::Call { func, .. } => {
+                if let Expr::Ident(fn_name) = &func.node {
+                    self.resolved_function_sigs
+                        .get(fn_name)
+                        .and_then(|sig| classify(&sig.ret))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        variant
+            .map(|name| self.get_enum_variant_tag(name))
+            .unwrap_or_else(|| self.get_enum_variant_tag("Err"))
+    }
+
     pub(super) fn ast_type_to_resolved(&self, ty: &Type) -> ResolvedType {
         match ty {
             Type::Named { name, generics } => match name.as_str() {
@@ -339,8 +369,7 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
 
     pub(super) fn generate_try(&mut self, inner: &Expr) -> CodegenResult<BasicValueEnum<'ctx>> {
         // Try (?) operator - propagate error if Result/Option is error/None
-        // Result/Optional layout: { i8 tag, i64 payload } where tag 0=Ok/Some, 1=Err/None (for Result)
-        // and tag 0=None, 1=Some (for Option)
+        // Result/Optional layout: `{ i32 tag, { i64... } payload }`.
         let val = self.generate_expr(inner)?;
 
         // If the value is not a struct (e.g. primitive), just return it as-is (no unwrapping needed)
@@ -351,8 +380,8 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
         let struct_val = val.into_struct_value();
         let struct_type = struct_val.get_type();
 
-        // Only handle { i8, i64 } shaped structs (Result/Optional)
-        if struct_type.count_fields() != 2 {
+        // Only handle enum-shaped structs.
+        if struct_type.count_fields() < 2 {
             return Ok(struct_val.into());
         }
 
@@ -367,20 +396,15 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
             .into_int_value();
 
-        // Check if error: for Result, tag != 0 means Err; for Option, tag == 0 means None
-        // We use the Result convention (tag 0 = Ok/Some success path)
-        // Actually in this codebase: Ok tag=0, Some tag=1, None tag=0, Err tag=1
-        // So for both Result and Option, tag != 0 means error/None needs propagation
-        // Wait - Some is tag=1 and None is tag=0 for Option. That means for Option,
-        // tag==0 is the error case (None). For Result, tag!=0 (Err=1) is error.
-        // Since we can't easily distinguish at codegen level, we use Result convention:
-        // tag != 0 means error -> propagate. This is consistent with Ok=0, Err=1.
+        // Result propagates Err; Option propagates None. Use resolved local/call
+        // type when available so declaration-order tags stay authoritative.
+        let error_tag = self.enum_error_tag_for_expr(inner);
         let is_error = self
             .builder
             .build_int_compare(
-                inkwell::IntPredicate::NE,
+                inkwell::IntPredicate::EQ,
                 tag,
-                tag.get_type().const_int(0, false),
+                tag.get_type().const_int(error_tag as u64, false),
                 "try_is_err",
             )
             .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
@@ -398,19 +422,26 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             .build_return(Some(&struct_val))
             .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
 
-        // Ok path: extract payload (field 1)
+        // Ok path: extract payload slot 0 (field 1 is the payload struct)
         self.builder.position_at_end(ok_block);
-        let payload = self
+        let payload_struct = self
             .builder
             .build_extract_value(struct_val, 1, "try_payload")
             .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
+        let payload = if payload_struct.is_struct_value() {
+            self.builder
+                .build_extract_value(payload_struct.into_struct_value(), 0, "try_payload_slot")
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+        } else {
+            payload_struct
+        };
 
         Ok(payload)
     }
 
     pub(super) fn generate_unwrap(&mut self, inner: &Expr) -> CodegenResult<BasicValueEnum<'ctx>> {
         // Unwrap (!) operator - panic if Result/Option is error/None
-        // Result/Optional layout: { i8 tag, i64 payload } where tag 0=Ok, 1=Err
+        // Result/Optional layout: `{ i32 tag, { i64... } payload }`.
         let val = self.generate_expr(inner)?;
 
         // If the value is not a struct, just return it as-is
@@ -421,8 +452,8 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
         let struct_val = val.into_struct_value();
         let struct_type = struct_val.get_type();
 
-        // Only handle { i8, i64 } shaped structs (Result/Optional)
-        if struct_type.count_fields() != 2 {
+        // Only handle enum-shaped structs.
+        if struct_type.count_fields() < 2 {
             return Ok(struct_val.into());
         }
 
@@ -437,13 +468,14 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
             .into_int_value();
 
-        // Check if error (tag != 0)
+        // Panic on Err/None, using declaration-order tags.
+        let error_tag = self.enum_error_tag_for_expr(inner);
         let is_error = self
             .builder
             .build_int_compare(
-                inkwell::IntPredicate::NE,
+                inkwell::IntPredicate::EQ,
                 tag,
-                tag.get_type().const_int(0, false),
+                tag.get_type().const_int(error_tag as u64, false),
                 "unwrap_is_err",
             )
             .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
@@ -466,12 +498,19 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
             .build_unreachable()
             .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
 
-        // Ok path: extract payload (field 1)
+        // Ok path: extract payload slot 0 (field 1 is the payload struct)
         self.builder.position_at_end(ok_block);
-        let payload = self
+        let payload_struct = self
             .builder
             .build_extract_value(struct_val, 1, "unwrap_payload")
             .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
+        let payload = if payload_struct.is_struct_value() {
+            self.builder
+                .build_extract_value(payload_struct.into_struct_value(), 0, "unwrap_payload_slot")
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+        } else {
+            payload_struct
+        };
 
         Ok(payload)
     }

--- a/crates/vais-codegen/src/inkwell/generator.rs
+++ b/crates/vais-codegen/src/inkwell/generator.rs
@@ -8,7 +8,8 @@ use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::module::Module;
 use inkwell::types::{BasicTypeEnum, StructType};
-use inkwell::values::{BasicValueEnum, FunctionValue, GlobalValue, PointerValue};
+use inkwell::values::{BasicValueEnum, FunctionValue, GlobalValue, IntValue, PointerValue};
+use inkwell::AddressSpace;
 
 use vais_ast::{self as ast, Expr, Module as VaisModule};
 use vais_types::ResolvedType;
@@ -93,16 +94,17 @@ pub struct InkwellCodeGenerator<'ctx> {
 
     /// Enum multi-field tuple variant payload struct types:
     /// (enum_name, variant_name) -> anonymous struct type that packs all fields.
-    /// Populated when a multi-field tuple variant (e.g., Rect(i64, i64)) is constructed;
-    /// pattern bindings use this to load the heap-allocated payload and extract each field.
+    /// Populated when a multi-field tuple variant (e.g., Rect(i64, i64)) is declared;
+    /// pattern bindings use this to decode each erased i64 payload slot back to its
+    /// declared field type.
     pub(super) enum_variant_multi_payload_types:
         HashMap<(String, String), inkwell::types::StructType<'ctx>>,
 
     /// Enum single-primitive variant payload LLVM type:
     /// (enum_name, variant_name) -> primitive BasicTypeEnum (f64, i32, ...) for
-    /// variants whose sole payload is a non-struct primitive. The enum data
-    /// slot always stores this as i64 (bitcast for floats, widen for smaller
-    /// ints), but pattern bindings need to recover the declared type so the
+    /// variants whose sole payload is a non-struct primitive. The enum payload
+    /// slot stores this as i64 (bitcast for floats, widen for smaller ints),
+    /// but pattern bindings need to recover the declared type so the
     /// bound identifier has the right type when referenced downstream.
     pub(super) enum_variant_primitive_payload_types:
         HashMap<(String, String), inkwell::types::BasicTypeEnum<'ctx>>,
@@ -299,6 +301,245 @@ impl<'ctx> InkwellCodeGenerator<'ctx> {
     #[inline]
     pub(super) fn unit_value(&self) -> BasicValueEnum<'ctx> {
         self.context.struct_type(&[], false).const_zero().into()
+    }
+
+    /// Return the canonical erased enum type used by Option/Result in the
+    /// inkwell backend, and mirror it in the generator's named-struct table.
+    pub(super) fn erased_enum_type(&mut self, enum_name: &str) -> StructType<'ctx> {
+        if let Some(ty) = self.generated_structs.get(enum_name).copied() {
+            return ty;
+        }
+        let ty = self.type_mapper.erased_enum_struct_type(enum_name);
+        self.generated_structs.insert(enum_name.to_string(), ty);
+        ty
+    }
+
+    /// Build a value for the canonical enum ABI `{ i32 tag, { i64... } payload }`.
+    /// Unit-only enums have no payload field; missing payload slots are zero-filled.
+    pub(super) fn build_erased_enum_value(
+        &self,
+        enum_type: StructType<'ctx>,
+        tag: i32,
+        payload_slots: &[IntValue<'ctx>],
+        name: &str,
+    ) -> CodegenResult<BasicValueEnum<'ctx>> {
+        let mut value = enum_type.get_undef();
+        let tag_type = match enum_type.get_field_type_at_index(0) {
+            Some(BasicTypeEnum::IntType(int_ty)) => int_ty,
+            _ => self.context.i32_type(),
+        };
+        value = self
+            .builder
+            .build_insert_value(
+                value,
+                tag_type.const_int(tag as u64, false),
+                0,
+                &format!("{}_tag", name),
+            )
+            .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+            .into_struct_value();
+
+        if enum_type.count_fields() > 1 {
+            let payload_type = match enum_type.get_field_type_at_index(1) {
+                Some(BasicTypeEnum::StructType(payload_type)) => payload_type,
+                _ => self
+                    .context
+                    .struct_type(&[self.context.i64_type().into()], false),
+            };
+            let mut payload = payload_type.get_undef();
+            for idx in 0..payload_type.count_fields() {
+                let slot = payload_slots
+                    .get(idx as usize)
+                    .copied()
+                    .unwrap_or_else(|| self.context.i64_type().const_int(0, false));
+                payload = self
+                    .builder
+                    .build_insert_value(payload, slot, idx, &format!("{}_data_{}", name, idx))
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+                    .into_struct_value();
+            }
+            value = self
+                .builder
+                .build_insert_value(value, payload, 1, &format!("{}_payload", name))
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+                .into_struct_value();
+        }
+
+        Ok(value.into())
+    }
+
+    /// Erase an arbitrary payload value into one canonical i64 enum payload slot.
+    pub(super) fn erase_enum_payload_to_i64(
+        &self,
+        value: BasicValueEnum<'ctx>,
+        name: &str,
+    ) -> CodegenResult<IntValue<'ctx>> {
+        if value.is_struct_value() {
+            let struct_val = value.into_struct_value();
+            let struct_ty = struct_val.get_type();
+            let target_data = inkwell::targets::TargetData::create(
+                &self.module.get_triple().as_str().to_string_lossy(),
+            );
+            let size_bytes = target_data.get_store_size(&struct_ty);
+            let i64_ty = self.context.i64_type();
+            if size_bytes > 8 {
+                let i8_ptr_ty = self.context.i8_type().ptr_type(AddressSpace::default());
+                let malloc_fn = self
+                    .module
+                    .get_function("malloc")
+                    .or_else(|| {
+                        let malloc_ty = i8_ptr_ty.fn_type(&[i64_ty.into()], false);
+                        Some(self.module.add_function("malloc", malloc_ty, None))
+                    })
+                    .unwrap();
+                let heap_ptr = self
+                    .builder
+                    .build_call(
+                        malloc_fn,
+                        &[i64_ty.const_int(size_bytes, false).into()],
+                        &format!("{}_heap", name),
+                    )
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+                    .try_as_basic_value()
+                    .basic()
+                    .ok_or_else(|| {
+                        crate::CodegenError::LlvmError(
+                            "ICE: malloc call returned void for enum payload".into(),
+                        )
+                    })?
+                    .into_pointer_value();
+                let typed_ptr = self
+                    .builder
+                    .build_bit_cast(
+                        heap_ptr,
+                        struct_ty.ptr_type(AddressSpace::default()),
+                        &format!("{}_heap_typed", name),
+                    )
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+                    .into_pointer_value();
+                self.builder
+                    .build_store(typed_ptr, struct_val)
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
+                self.builder
+                    .build_ptr_to_int(heap_ptr, i64_ty, &format!("{}_ptr_i64", name))
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))
+            } else {
+                let tmp_alloca = self
+                    .builder
+                    .build_alloca(struct_ty, &format!("{}_small_tmp", name))
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
+                self.builder
+                    .build_store(tmp_alloca, struct_val)
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
+                let i64_ptr = self
+                    .builder
+                    .build_bit_cast(
+                        tmp_alloca,
+                        i64_ty.ptr_type(AddressSpace::default()),
+                        &format!("{}_small_i64p", name),
+                    )
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+                    .into_pointer_value();
+                self.builder
+                    .build_load(i64_ty, i64_ptr, &format!("{}_small_i64", name))
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))
+                    .map(|v| v.into_int_value())
+            }
+        } else {
+            self.coerce_to_i64(value)
+        }
+    }
+
+    /// Decode one canonical i64 enum payload slot back into the declared LLVM type.
+    pub(super) fn decode_enum_payload_slot(
+        &self,
+        slot: IntValue<'ctx>,
+        declared_type: BasicTypeEnum<'ctx>,
+        name: &str,
+    ) -> CodegenResult<BasicValueEnum<'ctx>> {
+        if let BasicTypeEnum::StructType(struct_ty) = declared_type {
+            let target_data = inkwell::targets::TargetData::create(
+                &self.module.get_triple().as_str().to_string_lossy(),
+            );
+            let size_bytes = target_data.get_store_size(&struct_ty);
+            if size_bytes > 8 {
+                let ptr_ty = struct_ty.ptr_type(AddressSpace::default());
+                let heap_ptr = self
+                    .builder
+                    .build_int_to_ptr(slot, ptr_ty, &format!("{}_heap_ptr", name))
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
+                return self
+                    .builder
+                    .build_load(struct_ty, heap_ptr, &format!("{}_heap_load", name))
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()));
+            }
+
+            let i64_ty = self.context.i64_type();
+            let tmp_alloca = self
+                .builder
+                .build_alloca(i64_ty, &format!("{}_small_slot", name))
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
+            self.builder
+                .build_store(tmp_alloca, slot)
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?;
+            let typed_ptr = self
+                .builder
+                .build_bit_cast(
+                    tmp_alloca,
+                    struct_ty.ptr_type(AddressSpace::default()),
+                    &format!("{}_small_typed", name),
+                )
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+                .into_pointer_value();
+            return self
+                .builder
+                .build_load(struct_ty, typed_ptr, &format!("{}_small_load", name))
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()));
+        }
+
+        if let BasicTypeEnum::FloatType(float_ty) = declared_type {
+            let bit_width = float_ty.get_bit_width();
+            let source = if bit_width < 64 {
+                self.builder
+                    .build_int_truncate(
+                        slot,
+                        self.context.custom_width_int_type(bit_width),
+                        &format!("{}_f_trunc", name),
+                    )
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?
+            } else {
+                slot
+            };
+            return self
+                .builder
+                .build_bit_cast(source, float_ty, &format!("{}_to_float", name))
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()));
+        }
+
+        if let BasicTypeEnum::IntType(int_ty) = declared_type {
+            let decoded = match int_ty.get_bit_width().cmp(&64) {
+                std::cmp::Ordering::Equal => slot,
+                std::cmp::Ordering::Less => self
+                    .builder
+                    .build_int_truncate(slot, int_ty, &format!("{}_trunc", name))
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?,
+                std::cmp::Ordering::Greater => self
+                    .builder
+                    .build_int_s_extend(slot, int_ty, &format!("{}_sext", name))
+                    .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))?,
+            };
+            return Ok(decoded.into());
+        }
+
+        if let BasicTypeEnum::PointerType(ptr_ty) = declared_type {
+            return self
+                .builder
+                .build_int_to_ptr(slot, ptr_ty, &format!("{}_to_ptr", name))
+                .map_err(|e| crate::CodegenError::LlvmError(e.to_string()))
+                .map(Into::into);
+        }
+
+        Ok(slot.into())
     }
 
     /// Enable strict type mode.

--- a/crates/vais-codegen/src/inkwell/types.rs
+++ b/crates/vais-codegen/src/inkwell/types.rs
@@ -3,13 +3,14 @@
 use inkwell::context::Context;
 use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum, StructType};
 use inkwell::AddressSpace;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use vais_types::ResolvedType;
 
 /// Maps Vais types to LLVM types using inkwell.
 pub(crate) struct TypeMapper<'ctx> {
     context: &'ctx Context,
-    struct_types: HashMap<String, StructType<'ctx>>,
+    struct_types: RefCell<HashMap<String, StructType<'ctx>>>,
     /// Generic substitutions mirrored from InkwellCodeGenerator.
     /// Updated via `set_generic_substitutions` / `clear_generic_substitutions`.
     pub(crate) generic_substitutions: HashMap<String, ResolvedType>,
@@ -34,7 +35,7 @@ impl<'ctx> TypeMapper<'ctx> {
     pub(crate) fn new(context: &'ctx Context) -> Self {
         Self {
             context,
-            struct_types: HashMap::new(),
+            struct_types: RefCell::new(HashMap::new()),
             generic_substitutions: HashMap::new(),
             warnings: std::cell::RefCell::new(Vec::new()),
             strict_type_mode: true,
@@ -119,7 +120,38 @@ impl<'ctx> TypeMapper<'ctx> {
 
     /// Registers a named struct type.
     pub(crate) fn register_struct(&mut self, name: &str, struct_type: StructType<'ctx>) {
-        self.struct_types.insert(name.to_string(), struct_type);
+        self.struct_types
+            .borrow_mut()
+            .insert(name.to_string(), struct_type);
+    }
+
+    /// Look up a named struct type that was already registered.
+    pub(crate) fn get_registered_struct(&self, name: &str) -> Option<StructType<'ctx>> {
+        self.struct_types.borrow().get(name).copied()
+    }
+
+    /// Return the canonical erased enum ABI used for builtin generic enums.
+    ///
+    /// This mirrors the text backend layout: `%Option/%Result = { i32, { i64 } }`.
+    /// Generic parameters do not specialize the ABI; payload values are erased into
+    /// i64 slots, with larger aggregates stored indirectly.
+    pub(crate) fn erased_enum_struct_type(&self, name: &str) -> StructType<'ctx> {
+        if let Some(st) = self.get_registered_struct(name) {
+            return st;
+        }
+
+        let enum_type = self.context.opaque_struct_type(name);
+        let payload_type = self
+            .context
+            .struct_type(&[self.context.i64_type().into()], false);
+        enum_type.set_body(
+            &[self.context.i32_type().into(), payload_type.into()],
+            false,
+        );
+        self.struct_types
+            .borrow_mut()
+            .insert(name.to_string(), enum_type);
+        enum_type
     }
 
     /// Maps a Vais resolved type to an LLVM basic type.
@@ -211,13 +243,14 @@ impl<'ctx> TypeMapper<'ctx> {
                         .all(|g| !matches!(g, ResolvedType::Generic(_) | ResolvedType::Var(_)));
                     if all_concrete {
                         let mangled = vais_types::mangle_name(name, generics);
-                        if let Some(st) = self.struct_types.get(mangled.as_str()) {
-                            return (*st).into();
+                        if let Some(st) = self.struct_types.borrow().get(mangled.as_str()).copied()
+                        {
+                            return st.into();
                         }
                     }
                 }
-                if let Some(st) = self.struct_types.get(name.as_str()) {
-                    (*st).into()
+                if let Some(st) = self.struct_types.borrow().get(name.as_str()).copied() {
+                    st.into()
                 } else {
                     // Return opaque struct placeholder
                     self.context.opaque_struct_type(name).into()
@@ -269,22 +302,17 @@ impl<'ctx> TypeMapper<'ctx> {
                 self.context.struct_type(&elem_types, false).into()
             }
             ResolvedType::Optional(inner) => {
-                // Option<T> is { tag: i8, value: T }
-                let inner_llvm = self.map_type(inner);
-                let tag_type = self.context.i8_type();
-                self.context
-                    .struct_type(&[tag_type.into(), inner_llvm], false)
-                    .into()
+                // Walk the payload type to preserve strict generic/unresolved checks,
+                // but the ABI itself is erased and type-independent.
+                let _ = self.map_type(inner);
+                self.erased_enum_struct_type("Option").into()
             }
             ResolvedType::Result(ok, err) => {
-                // Result<T, E> is { tag: i8, value: max(T, E) }
-                let ok_llvm = self.map_type(ok);
-                let _err_llvm = self.map_type(err);
-                let tag_type = self.context.i8_type();
-                // Use ok type as payload (largest variant strategy handled by enum layout)
-                self.context
-                    .struct_type(&[tag_type.into(), ok_llvm], false)
-                    .into()
+                // Walk both payload types to preserve strict generic/unresolved checks,
+                // but the ABI itself is erased and type-independent.
+                let _ = self.map_type(ok);
+                let _ = self.map_type(err);
+                self.erased_enum_struct_type("Result").into()
             }
             ResolvedType::Map(key, value) => {
                 // Map is a pointer to runtime structure

--- a/crates/vais-codegen/src/types/sizeof.rs
+++ b/crates/vais-codegen/src/types/sizeof.rs
@@ -146,9 +146,10 @@ impl CodeGenerator {
                         }
                     }
                 }
-                // Try enums: { i8 tag, i64 payload } = 9 but typically padded to 16
+                // Native enums use `{ i32 tag, { i64... } payload }`; single-slot
+                // Option/Result values are 16 bytes after alignment.
                 if self.types.enums.contains_key(name) {
-                    return 16; // { i8, i64 } with alignment padding
+                    return 16;
                 }
                 // Try with generic-mangled names in generated_structs
                 if !generics.is_empty() {

--- a/crates/vais-codegen/tests/inkwell_enum_layout_tests.rs
+++ b/crates/vais-codegen/tests/inkwell_enum_layout_tests.rs
@@ -1,0 +1,56 @@
+#![cfg(feature = "inkwell-codegen")]
+
+use inkwell::context::Context;
+use vais_codegen::InkwellCodeGenerator;
+use vais_parser::parse;
+
+#[test]
+fn inkwell_option_uses_named_erased_layout_and_declared_tags() {
+    let source = r#"
+E Option<T> {
+    Some(T),
+    None
+}
+
+F main() -> i64 {
+    x: Option<i64> = Some(42)
+    R M x {
+        Some(v) => v,
+        None => 0
+    }
+}
+"#;
+
+    let module = parse(source).expect("source should parse");
+    let context = Context::create();
+    let mut gen = InkwellCodeGenerator::new(&context, "option_layout");
+    gen.generate_module(&module)
+        .expect("inkwell codegen should succeed");
+    let ir = gen.get_ir_string();
+
+    assert!(
+        ir.contains("%Option = type { i32, { i64 } }"),
+        "Option must use the canonical named erased ABI:\n{}",
+        ir
+    );
+    assert!(
+        !ir.contains("{ i8, i64 }"),
+        "Option must not fall back to the old anonymous i8-tag ABI:\n{}",
+        ir
+    );
+    assert!(
+        ir.contains("store %Option { i32 0, { i64 } { i64 42 } }"),
+        "Some must use the declaration-order tag and nested payload slot:\n{}",
+        ir
+    );
+    assert!(
+        ir.contains("icmp eq i32 %enum_tag, 0"),
+        "match must compare against the same i32 tag used by construction:\n{}",
+        ir
+    );
+    assert!(
+        ir.contains("extractvalue { i64 } %variant_payload, 0"),
+        "payload binding must extract from the nested erased payload struct:\n{}",
+        ir
+    );
+}

--- a/crates/vais-codegen/tests/text_enum_layout_tests.rs
+++ b/crates/vais-codegen/tests/text_enum_layout_tests.rs
@@ -1,0 +1,91 @@
+use vais_codegen::CodeGenerator;
+use vais_parser::parse;
+
+fn text_ir(source: &str) -> String {
+    let module = parse(source).unwrap_or_else(|e| panic!("Parse failed: {:?}", e));
+    let mut gen = CodeGenerator::new("text_enum_layout");
+    gen.generate_module(&module)
+        .unwrap_or_else(|e| panic!("Codegen failed for: {}\nErr: {}", source, e))
+}
+
+fn marker_window(ir: &str, marker: &str, lines: usize) -> String {
+    ir.split(marker)
+        .nth(1)
+        .unwrap_or_else(|| panic!("missing marker `{}` in IR:\n{}", marker, ir))
+        .lines()
+        .take(lines)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn text_option_unwrap_uses_declared_none_tag() {
+    let ir = text_ir(
+        r#"
+E Option<T> {
+    None,
+    Some(T)
+}
+
+F main() -> i64 {
+    x: Option<i64> = Some(42)
+    R x!
+}
+"#,
+    );
+
+    assert!(
+        ir.contains("%Option = type { i32, { i64 } }"),
+        "Option must use the canonical text backend ABI:\n{}",
+        ir
+    );
+    assert!(
+        ir.contains("store i32 1, i32*") && ir.contains("store i64 42, i64*"),
+        "Some must use declaration-order tag 1 when None is declared first:\n{}",
+        ir
+    );
+    let unwrap_ir = marker_window(&ir, "; Unwrap expression", 5);
+    assert!(
+        unwrap_ir.contains("icmp eq i32") && unwrap_ir.contains(", 0"),
+        "unwrap must compare against the declared None tag, not tag != 0:\n{}",
+        unwrap_ir
+    );
+    assert!(
+        !unwrap_ir.contains("icmp ne i32"),
+        "unwrap must not assume nonzero tags are errors:\n{}",
+        unwrap_ir
+    );
+}
+
+#[test]
+fn text_option_try_uses_declared_none_tag() {
+    let ir = text_ir(
+        r#"
+E Option<T> {
+    Some(T),
+    None
+}
+
+F maybe() -> Option<i64> {
+    R Some(7)
+}
+
+F main() -> Option<i64> {
+    x := maybe()?
+    R Some(x)
+}
+"#,
+    );
+
+    assert!(
+        ir.contains("store i32 0, i32*") && ir.contains("store i64 7, i64*"),
+        "Some must use declaration-order tag 0 when declared first:\n{}",
+        ir
+    );
+    let try_ir = marker_window(&ir, "; Try expression (?)", 5);
+    assert!(
+        try_ir.contains("icmp eq i32") && try_ir.contains(", 1"),
+        "try must propagate the declared None tag, not any nonzero tag:\n{}",
+        try_ir
+    );
+}

--- a/docs/LANGUAGE_SPEC.md
+++ b/docs/LANGUAGE_SPEC.md
@@ -765,6 +765,32 @@ opt := Some(42)
 err := Err("file not found")
 ```
 
+### Enum Runtime Layout
+
+Enum discriminants are assigned by declaration order, starting at `0`. The tag is
+part of the language ABI, not a backend detail: every backend uses an `i32` tag.
+
+The canonical native LLVM layout is:
+
+```llvm
+%Enum = type { i32 }                  ; unit-only enum
+%Enum = type { i32, { i64, ... } }    ; enum with payload fields
+```
+
+Payload fields are erased into fixed `i64` slots. Values that do not fit in one
+slot are stored indirectly and the pointer is placed in the slot. Generic enums
+such as `Option<T>` and `Result<T, E>` use the same named base layout for every
+instantiation, for example:
+
+```llvm
+%Option = type { i32, { i64 } }
+%Result = type { i32, { i64 } }
+```
+
+Backends must not emit an anonymous alternate layout for the same source enum
+instantiation. In particular, `{ i8, i64 }` is not a valid native layout for
+`Option<T>` or `Result<T, E>`.
+
 ### Enum Implementation Blocks
 
 Enums can have methods just like structs:


### PR DESCRIPTION
## Summary
- canonicalize text and inkwell enum ABI around declaration-order i32 tags
- make Option/Result use named erased layouts instead of anonymous i8-tag structs in inkwell
- update try/unwrap/runtime helpers to use declared Some/None/Ok/Err tags
- document the enum runtime layout and add text/inkwell regression tests

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vais-codegen
- cargo test -p vaisc --test e2e phase90_enums -- --nocapture
- cargo test -p vaisc --test e2e phase41_error_handling -- --nocapture
- cargo test -p vaisc --test e2e phase91_lifetime -- --nocapture
- cargo clippy -p vais-codegen -p vaisc --all-targets -- -D warnings

## Notes
- Stacked on #60 / codex/a4-auto-deref-strict.