### PR TITLE
types: require explicit pointer integer boundary

### DIFF
--- a/crates/vais-types/src/inference/unification.rs
+++ b/crates/vais-types/src/inference/unification.rs
@@ -277,13 +277,6 @@ impl TypeChecker {
                     Ok(())
                 }
             }
-            // Pointer <-> i64 implicit unification.
-            // Vais represents all pointers as i64 at the IR level (no opaque pointer distinction).
-            // This allows builtins like vec_new() -> i64 and malloc() -> i64 to unify with *T
-            // parameters, and swap(ptr, i, j) to accept either pointer or i64 arguments.
-            // Scope: unification only — does not enable arbitrary pointer arithmetic in user code.
-            (ResolvedType::Pointer(_), ResolvedType::I64)
-            | (ResolvedType::I64, ResolvedType::Pointer(_)) => Ok(()),
             // Pointer<T> ↔ Slice<T> / SliceMut<T> auto-coercion (Phase 162).
             // *u8 and &[u8] are compatible in systems code — both represent byte buffers.
             // Unifies element types to maintain generic consistency.

--- a/crates/vais-types/tests/inference_unification_tests.rs
+++ b/crates/vais-types/tests/inference_unification_tests.rs
@@ -202,6 +202,16 @@ fn test_unify_ref_pointer_array_to_slice_allowed() {
     );
 }
 
+#[test]
+fn test_unify_pointer_to_i64_rejected_without_explicit_cast() {
+    tc_err("F test(p: *i64) -> i64 { x: i64 = p; R 0 }");
+}
+
+#[test]
+fn test_unify_i64_to_pointer_rejected_without_explicit_cast() {
+    tc_err("F test(x: i64) -> *i64 = x");
+}
+
 // ============================================================================
 // Unification — Never type
 // ============================================================================

--- a/crates/vaisc/tests/e2e/phase158_type_strict.rs
+++ b/crates/vaisc/tests/e2e/phase158_type_strict.rs
@@ -1,13 +1,14 @@
-//! Phase 158: Type Coercion Prohibition E2E Tests
+//! Type conversion E2E tests.
 //!
-//! Verifies that implicit type coercions forbidden by Phase 158's Rust-style
-//! strict type rules are rejected at compile time, and that explicitly permitted
-//! conversions (integer widening, explicit `as` casts) continue to work.
+//! Verifies that forbidden structural conversions are rejected at compile time,
+//! and that explicitly permitted numeric adaptation and explicit `as` casts
+//! continue to work.
 //!
-//! Phase 158 rules (see CLAUDE.md "Type Conversion Rules"):
-//!   Allowed (implicit):  integer widening only — i8→i16→i32→i64, u8→u16→u32→u64
-//!   Forbidden:           bool↔i64, int↔float, f32↔f64, str↔i64, integer narrowing
-//!   All other conversions require an explicit `as` keyword.
+//! Current rules (see LANGUAGE_SPEC.md "Type Conversion Rules"):
+//!   Allowed (implicit):  numeric adaptation across integer widths/signs,
+//!                        int↔float numeric promotion, f32↔f64 literal inference
+//!   Forbidden:           bool↔i64, str↔i64, typed pointer↔i64
+//!   All other structural conversions require an explicit conversion boundary.
 
 use crate::helpers::{assert_compiles, assert_exit_code};
 
@@ -89,6 +90,18 @@ fn e2e_phase158_strict_str_to_i64_return() {
     assert_error_contains(r#"F main() -> i64 = "hello""#, "mismatch");
 }
 
+/// Typed pointer values do not implicitly unify with raw i64 addresses.
+#[test]
+fn e2e_phase158_strict_pointer_to_i64_return() {
+    assert_error_contains(
+        r#"
+F addr(p: *i64) -> i64 = p
+F main() -> i64 = 0
+"#,
+        "mismatch",
+    );
+}
+
 /// Bool arithmetic still requires numeric type — `+` operator requires numeric, not bool.
 #[test]
 fn e2e_phase158_strict_bool_in_arithmetic() {
@@ -100,7 +113,7 @@ F main() -> i64 { x := true; x + 1 }
 
 // ==================== B. Permitted Conversions (must succeed) ====================
 
-/// Phase 158 rule: integer widening i32→i64 is permitted (integer unification).
+/// Integer numeric unification permits i32→i64 in this return context.
 #[test]
 fn e2e_phase158_strict_i32_to_i64_widening() {
     // A variable declared as i32 can be returned as i64 via widening
@@ -112,7 +125,7 @@ F main() -> i64 { x:i32 = 1; x }
     );
 }
 
-/// Phase 158 rule: integer widening i8→i64 is permitted.
+/// Integer numeric unification permits i8→i64 in this return context.
 #[test]
 fn e2e_phase158_strict_i8_to_i64_widening() {
     assert_exit_code(
@@ -123,7 +136,7 @@ F main() -> i64 { x:i8 = 5; x }
     );
 }
 
-/// Phase 158 rule: integer widening u8→i64 is permitted.
+/// Integer numeric unification permits u8→i64 in this return context.
 #[test]
 fn e2e_phase158_strict_u8_to_i64_widening() {
     assert_exit_code(
@@ -140,10 +153,10 @@ fn e2e_phase158_strict_i64_literal_return() {
     assert_exit_code(r#"F main() -> i64 = 42"#, 42);
 }
 
-/// Phase 158 rule: typed integer literal (i32 suffix) is valid — inferred as i32, widened to i64.
+/// Typed integer literal (i32 suffix) is valid and adapts to i64 context.
 #[test]
 fn e2e_phase158_strict_typed_int_literal_i32() {
-    // `1i32` is a typed integer literal; widening to i64 return is permitted
+    // `1i32` is a typed integer literal; adaptation to i64 return is permitted.
     assert_exit_code(
         r#"
 F main() -> i64 { x := 1i32; x }
@@ -187,10 +200,9 @@ fn e2e_phase158_strict_trivial_compile() {
 // ==================== E. Phase 158 CI Gate (source-level) ====================
 //
 // ROADMAP #4: guard against regression by scanning `vais-types/src/inference/unification.rs`
-// for forbidden coercion patterns. If any of these names appear in the source the gate
-// fails, forcing the author to either rename the function or acknowledge a Phase 158 RFC.
-//
-// The list mirrors CLAUDE.md "Type Conversion Rules" and BASELINE_2026-04-11.md section 6.
+// for forbidden structural coercion patterns. If any of these names appear in
+// the source the gate fails, forcing the author to either rename the function or
+// update the language conversion rules in the same change.
 
 /// Locate the unification source file regardless of where `cargo test` is run from.
 fn find_unification_rs() -> Option<std::path::PathBuf> {
@@ -226,20 +238,18 @@ fn e2e_phase158_ci_gate_no_forbidden_coercions() {
     let src = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
 
-    // Forbidden function-name fragments. These are the coercion shapes that
-    // Phase 158 explicitly prohibits — adding any of them reintroduces the
-    // yo-yo pattern that the rule exists to prevent.
+    // Forbidden function-name fragments. These are structural coercion shapes
+    // that the language explicitly prohibits as implicit unification.
     const FORBIDDEN: &[&str] = &[
         "coerce_bool",
         "bool_to_i64",
         "i64_to_bool",
-        "int_to_float",
-        "float_to_int",
         "str_to_i64",
         "i64_to_str",
-        "narrow_int",
         "coerce_to_i64",
         "as_i64_implicit",
+        "pointer_to_i64",
+        "i64_to_pointer",
     ];
 
     let mut hits: Vec<&str> = Vec::new();
@@ -252,10 +262,8 @@ fn e2e_phase158_ci_gate_no_forbidden_coercions() {
         hits.is_empty(),
         "Phase 158 CI gate: forbidden coercion identifier(s) found in \
          vais-types/src/inference/unification.rs: {:?}. \
-         Type coercion rules were tightened in Phase 158 (see CLAUDE.md \
-         'Type Conversion Rules'). If you genuinely need to reintroduce one \
-         of these conversions, update this gate list and the CLAUDE.md rules \
-         in the same commit.",
+         If you genuinely need to reintroduce one of these conversions, update \
+         this gate list and LANGUAGE_SPEC.md in the same commit.",
         hits
     );
 }

--- a/docs/LANGUAGE_SPEC.md
+++ b/docs/LANGUAGE_SPEC.md
@@ -202,36 +202,43 @@ Vec<T>      # Generic vector type
 Pair<A, B>  # Multiple type parameters
 ```
 
-### Type Conversion Rules (Phase 158)
+### Type Conversion Rules
 
-Vais uses strict Rust-style type coercion. Implicit widening is allowed only in a narrow set of cases; all other conversions require an explicit `as` cast. These rules were finalized in **Phase 158** to eliminate the yo-yo pattern where `unification.rs` coercion was toggled repeatedly.
+Vais keeps structural types strict, while numeric primitives may adapt to the
+expected numeric context. These rules are part of the language type contract, not
+a backend fallback.
 
 **Implicit (automatic) conversions:**
-- Integer widening: `i8 → i16 → i32 → i64`, `u8 → u16 → u32 → u64`
-- Float literal inference: `f32 ↔ f64` (the literal is inferred from context, identical to Rust behavior)
+- Integer numeric unification across integer widths and signedness.
+- Integer/float numeric promotion when the expected type is numeric.
+- Float literal inference between `f32` and `f64`.
 
-**Prohibited implicit conversions — explicit `as` required:**
-- `bool ↔ i64`: use `flag as i64` or `n != 0`
-- `int ↔ float`: use `x as f64` or `y as i64`
-- `str ↔ i64`: use parsing functions or `n as str`
-- Integer narrowing (`i64 → i32`): use `x as i32`
+**Prohibited implicit conversions — explicit conversion required:**
+- `bool ↔ i64`: use `flag as i64` or `n != 0`.
+- `str ↔ i64`: use string parsing/formatting helpers or `str_to_ptr`/`ptr_to_str`
+  for raw pointer interop.
+- `*T ↔ i64`: typed pointer values do not implicitly unify with raw integer
+  addresses. Low-level memory APIs such as `malloc`, `free`, `load_i64`, and
+  `store_i64` expose raw addresses as `i64`; code using typed `*T` must not rely
+  on implicit pointer/integer conversion.
 
 ```vais
-# Allowed implicit widening
+# Allowed numeric adaptation
 x: i8 = 10
-y: i64 = x          # OK: i8 → i64
+y: i64 = x          # OK: integer numeric context
+z: f64 = 3          # OK: numeric promotion
 
 # Explicit cast required
 flag: bool = true
 n: i64 = flag as i64        # OK: explicit as
-val: f64 = 3 as f64         # OK: explicit as
 
 # Prohibited — compile error
 bad: i64 = true             # ERROR: bool → i64 implicit
-bad2: i64 = 3.14            # ERROR: float → int implicit
+bad2: i64 = "hello"         # ERROR: str → i64 implicit
 ```
 
-**E2E protection test:** `vais-types/tests/phase158_type_strict.rs` enforces these rules.
+**E2E protection test:** `vaisc/tests/e2e/phase158_type_strict.rs` and
+`vais-types/tests/inference_unification_tests.rs` enforce these rules.
 
 ### Linear and Affine Types (Experimental)
 


### PR DESCRIPTION
## Summary
- remove implicit *T <-> i64 unification from the type checker
- add unit and e2e coverage that rejects typed pointer/raw address mixing without an explicit boundary
- update LANGUAGE_SPEC type conversion rules to match the current numeric adaptation policy and the strict pointer/integer boundary

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vais-types --test inference_unification_tests -- --nocapture
- cargo test -p vaisc --test e2e phase158_type_strict -- --nocapture
- cargo test -p vais-types
- cargo test -p vaisc --test e2e phase134_errors -- --nocapture
- cargo clippy -p vais-types -p vaisc --all-targets -- -D warnings

Stacked on #61, which is stacked on #60.